### PR TITLE
Add support for dots in variable names

### DIFF
--- a/Sources/SwaggerSwift/Models/FunctionParameter.swift
+++ b/Sources/SwaggerSwift/Models/FunctionParameter.swift
@@ -15,4 +15,20 @@ struct FunctionParameter {
     let required: Bool
     let `in`: In
     let isEnum: Bool
+
+    var variableName: String {
+        name.variableNameFormatted
+    }
+}
+
+extension String {
+    var variableNameFormatted: String {
+        split(separator: ".")
+            .map { $0.split(separator: "-") }
+            .flatMap { $0 }
+            .map { String($0).capitalizingFirstLetter() }
+            .joined()
+            .camelized
+            .lowercasingFirst
+    }
 }

--- a/Sources/SwaggerSwift/Models/FunctionParameter.swift
+++ b/Sources/SwaggerSwift/Models/FunctionParameter.swift
@@ -1,7 +1,18 @@
 /// describes a single parameter to a function
 struct FunctionParameter {
+    enum In {
+        case body
+        case formData
+        case headers
+        case path
+        case query
+        case nowhere
+    }
+
     let description: String?
     let name: String
     let typeName: TypeType
     let required: Bool
+    let `in`: In
+    let isEnum: Bool
 }

--- a/Sources/SwaggerSwift/getFunctionParameters.swift
+++ b/Sources/SwaggerSwift/getFunctionParameters.swift
@@ -4,9 +4,10 @@ import SwaggerSwiftML
 /// - Parameter headerName:
 /// - Returns: the field name to use in the Swift struct
 func makeHeaderFieldName(headerName: String) -> String {
-    headerName.replacingOccurrences(of: "X-", with: "")
+    headerName
+        .replacingOccurrences(of: "X-", with: "")
         .replacingOccurrences(of: "x-", with: "")
-        .lowercasingFirst
+        .variableNameFormatted
 }
 
 func getFunctionParameters(_ parameters: [Parameter], functionName: String, isInternalOnly: Bool, responseTypes: [(HTTPStatusCodes, TypeType)], swagger: Swagger, swaggerFile: SwaggerFile) -> ([FunctionParameter], [ModelDefinition]) {

--- a/Sources/SwaggerSwift/getFunctionParameters.swift
+++ b/Sources/SwaggerSwift/getFunctionParameters.swift
@@ -77,7 +77,8 @@ func getFunctionParameters(_ parameters: [Parameter], functionName: String, isIn
                                      name: $0.name,
                                      typeName: result.0,
                                      required: $0.required,
-                                     in: .path, isEnum: false)
+                                     in: .path,
+                                     isEnum: false)
         } else {
             return nil
         }
@@ -95,7 +96,9 @@ func getFunctionParameters(_ parameters: [Parameter], functionName: String, isIn
             return FunctionParameter(description: $0.description,
                                      name: $0.name.camelized,
                                      typeName: result.0,
-                                     required: $0.required, in: .query, isEnum: false)
+                                     required: $0.required,
+                                     in: .query,
+                                     isEnum: false)
         } else {
             return nil
         }
@@ -128,7 +131,8 @@ func getFunctionParameters(_ parameters: [Parameter], functionName: String, isIn
                                                   name: $0.name,
                                                   typeName: .object(typeName: typeName),
                                                   required: !allowEmpty,
-                                                  in: .formData, isEnum: true)
+                                                  in: .formData,
+                                                  isEnum: true)
 
                     return (param, modelDefinitions)
                 } else {
@@ -137,7 +141,8 @@ func getFunctionParameters(_ parameters: [Parameter], functionName: String, isIn
                                                   name: $0.name,
                                                   typeName: typeName.0,
                                                   required: !allowEmpty,
-                                                  in: .formData, isEnum: false)
+                                                  in: .formData,
+                                                  isEnum: false)
 
                     return (param, modelDefinitions)
                 }
@@ -155,7 +160,8 @@ func getFunctionParameters(_ parameters: [Parameter], functionName: String, isIn
                                               name: $0.name,
                                               typeName: typeName.0,
                                               required: !allowEmpty,
-                                              in: .formData, isEnum: false)
+                                              in: .formData,
+                                              isEnum: false)
 
                 return (param, modelDefinitions)
             }

--- a/Sources/SwaggerSwift/getFunctionParameters.swift
+++ b/Sources/SwaggerSwift/getFunctionParameters.swift
@@ -57,7 +57,12 @@ func getFunctionParameters(_ parameters: [Parameter], functionName: String, isIn
 
         if model.fields.count > 0 {
             resolvedModelDefinitions.append(.model(model))
-            resolvedParameters.append(FunctionParameter(description: nil, name: "headers", typeName: .object(typeName: typeName), required: true))
+            resolvedParameters.append(FunctionParameter(description: nil,
+                                                        name: "headers",
+                                                        typeName: .object(typeName: typeName),
+                                                        required: true,
+                                                        in: .headers,
+                                                        isEnum: false))
         }
     }
 
@@ -68,7 +73,11 @@ func getFunctionParameters(_ parameters: [Parameter], functionName: String, isIn
             let result = type.toType(typePrefix: typeName, swagger: swagger)
             assert(result.1.count == 0, "A path param isnt expected to contain a special model definition inline, is it?")
             resolvedModelDefinitions.append(contentsOf: result.1)
-            return FunctionParameter(description: $0.description, name: $0.name, typeName: result.0, required: $0.required)
+            return FunctionParameter(description: $0.description,
+                                     name: $0.name,
+                                     typeName: result.0,
+                                     required: $0.required,
+                                     in: .path, isEnum: false)
         } else {
             return nil
         }
@@ -86,7 +95,7 @@ func getFunctionParameters(_ parameters: [Parameter], functionName: String, isIn
             return FunctionParameter(description: $0.description,
                                      name: $0.name.camelized,
                                      typeName: result.0,
-                                     required: $0.required)
+                                     required: $0.required, in: .query, isEnum: false)
         } else {
             return nil
         }
@@ -96,21 +105,64 @@ func getFunctionParameters(_ parameters: [Parameter], functionName: String, isIn
 
     // Body
 
-    let bodyParams: [(FunctionParameter, [ModelDefinition])] = parameters.map {
+    let bodyParams: [(FunctionParameter, [ModelDefinition])] = parameters.compactMap {
         switch $0.location {
         case .body(schema: let schemaNode):
             let schema = swagger.findSchema(node: schemaNode.value)
             let type = getType(forSchema: schema, typeNamePrefix: typeName, swagger: swagger)
-            let param = FunctionParameter(description: $0.description, name: "body", typeName: type.0, required: $0.required)
+            let param = FunctionParameter(description: $0.description, name: "body", typeName: type.0, required: $0.required, in: .body, isEnum: false)
             return (param, type.1)
         case .formData(type: let paramType, allowEmptyValue: let allowEmpty):
-            let typeName = paramType.toType(typePrefix: typeName, swagger: swagger)
-            let param = FunctionParameter(description: $0.description, name: $0.name, typeName: typeName.0, required: !allowEmpty)
-            return (param, [])
+            var modelDefinitions = [ModelDefinition]()
+            switch paramType {
+            case .string(format: _, enumValues: let enumValues, maxLength: _, minLength: _, pattern: _):
+                if let enumValues = enumValues {
+                    let typeName = "\(typeName)\($0.name.camelized.capitalizingFirstLetter())"
+                    modelDefinitions.append(.enumeration(.init(serviceName: swagger.serviceName,
+                                                               description: $0.description,
+                                                               typeName: typeName,
+                                                               values: enumValues,
+                                                               isCodable: true)))
+
+                    let param = FunctionParameter(description: $0.description,
+                                                  name: $0.name,
+                                                  typeName: .object(typeName: typeName),
+                                                  required: !allowEmpty,
+                                                  in: .formData, isEnum: true)
+
+                    return (param, modelDefinitions)
+                } else {
+                    let typeName = paramType.toType(typePrefix: typeName, swagger: swagger)
+                    let param = FunctionParameter(description: $0.description,
+                                                  name: $0.name,
+                                                  typeName: typeName.0,
+                                                  required: !allowEmpty,
+                                                  in: .formData, isEnum: false)
+
+                    return (param, modelDefinitions)
+                }
+            case .number(format: _, maximum: _, exclusiveMaximum: _, minimum: _, exclusiveMinimum: _, multipleOf: _):
+                fatalError("Not implemented")
+            case .integer(format: _, maximum: _, exclusiveMaximum: _, minimum: _, exclusiveMinimum: _, multipleOf: _):
+                fatalError("Not implemented")
+            case .boolean:
+                fatalError("Not implemented")
+            case .array(_, collectionFormat: _, maxItems: _, minItems: _, uniqueItems: _):
+                fatalError("Not implemented")
+            case .file:
+                let typeName = paramType.toType(typePrefix: typeName, swagger: swagger)
+                let param = FunctionParameter(description: $0.description,
+                                              name: $0.name,
+                                              typeName: typeName.0,
+                                              required: !allowEmpty,
+                                              in: .formData, isEnum: false)
+
+                return (param, modelDefinitions)
+            }
+
         default: return nil
         }
-
-    }.compactMap { $0 }
+    }
 
     resolvedParameters.append(contentsOf: bodyParams.map { $0.0 })
     resolvedModelDefinitions.append(contentsOf: bodyParams.flatMap { $0.1 })
@@ -121,7 +173,7 @@ func getFunctionParameters(_ parameters: [Parameter], functionName: String, isIn
     let successType = successTypeResult.0
     let failureTypeResult = createResultEnumType(types: responseTypes, failure: true, functionName: functionName, swagger: swagger)
     let failureType = failureTypeResult.0
-    let completionHandler = FunctionParameter(description: "The completion handler of the function returns as soon as the request completes", name: "completionHandler", typeName: .object(typeName: "@escaping (Result<\(successType), ServiceError<\(failureType)>>) -> Void = { _ in }"), required: true)
+    let completionHandler = FunctionParameter(description: "The completion handler of the function returns as soon as the request completes", name: "completionHandler", typeName: .object(typeName: "@escaping (Result<\(successType), ServiceError<\(failureType)>>) -> Void = { _ in }"), required: true, in: .nowhere, isEnum: false)
 
     resolvedParameters.append(completionHandler)
     resolvedModelDefinitions.append(contentsOf: successTypeResult.1)

--- a/Sources/SwaggerSwift/start.swift
+++ b/Sources/SwaggerSwift/start.swift
@@ -67,37 +67,50 @@ let formData = """
 import Foundation
 
 public struct FormData {
+    private let crlf = "\\r\\n"
+
     /// the data representation of the object
     public let data: Data
     /// the mime type for the data, e.g. `image/png`
-    public let mimeType: String
+    public let mimeType: String?
     /// a filename representing the input - e.g. `image.png`
-    public let filename: String
+    public let filename: String?
 
     /// Creates the data part of a multi part request
     /// - Parameters:
     ///   - data: the piece of data being sent
     ///   - mimeType: the mime type for the data, e.g. `image/png`
     ///   - fileName: a filename representing the input - e.g. `image.png`
-    public init(data: Data, mimeType: String, fileName: String) {
+    public init(data: Data, mimeType: String? = nil, fileName: String? = nil) {
         self.data = data
         self.mimeType = mimeType
         self.filename = fileName
     }
 
     internal func toRequestData(named fieldName: String, using boundary: String) -> Data {
-        func append(string: String, toData data: NSMutableData) {
+        func append(string: String, toData data: inout Data) {
             guard let strData = string.data(using: .utf8) else { return }
             data.append(strData)
         }
 
-        let mutableData = NSMutableData()
+        var contentDisposition = "Content-Disposition: form-data; name=\\"\\(fieldName)\\""
+        if let filename = filename {
+            contentDisposition += "; filename=\\"\\(filename)\\""
+        }
 
-        append(string: "--\\(boundary)\\r\\n", toData: mutableData)
-        append(string: "Content-Disposition: form-data; name=\\"\\(fieldName)\\"; filename=\\"\\(filename)\\"\\r\\n", toData: mutableData)
-        append(string: "Content-Type: \\(mimeType)\\r\\n\\r\\n", toData: mutableData)
+        var mutableData = Data()
+
+        append(string: "--\\(boundary)" + crlf, toData: &mutableData)
+        append(string: contentDisposition + crlf, toData: &mutableData)
+        if let mimeType = mimeType {
+            append(string: "Content-Type: \\(mimeType)" + crlf + crlf, toData: &mutableData)
+        } else {
+            append(string: crlf, toData: &mutableData)
+        }
+
         mutableData.append(data)
-        append(string: "\\r\\n", toData: mutableData)
+
+        append(string: crlf, toData: &mutableData)
 
         return mutableData as Data
     }


### PR DESCRIPTION
formData variables supports having dots in their naming, such as gorilla.csrf.token. This would previously generate non-supported variables names in the swift code.

Also formData parameters can also be available without a consumes: multipart is defined. This would previously result in the variables not being added to the swift code. They will now be added, but wont be a part of the request before consumes is set correctly.