### PR TITLE
✨ Call completion Handler when interceptor took over

### DIFF
--- a/Sources/SwaggerSwift/Models/NetworkRequestFunction.swift
+++ b/Sources/SwaggerSwift/Models/NetworkRequestFunction.swift
@@ -210,6 +210,7 @@ if let \(($0.headerModelName)) = headers.\($0.headerModelName) {
     request = interceptor?.networkWillPerformRequest(request) ?? request
     let task = urlSession().\(urlSessionMethodName) { (data, response, error) in
         if let interceptor = self.interceptor, interceptor.networkDidPerformRequest(urlRequest: request, urlResponse: response, data: data, error: error) == false {
+            completionHandler(.failure(ServiceError.requestInterceptedError))
             return
         }
 

--- a/Sources/SwaggerSwift/start.swift
+++ b/Sources/SwaggerSwift/start.swift
@@ -15,6 +15,8 @@ public enum ServiceError<ErrorType>: Error {
     case requestFailed(error: Error)
     // The backend returned an error, e.g. a 500 Internal Server Error, 403 Unauthorized
     case backendError(error: ErrorType)
+    // An interceptor handled the request and took over
+    case requestInterceptedError
 }
 """
 


### PR DESCRIPTION
Add an error type for the case that an interceptor took over and call the completion handler with that error type when it did.