### PR TITLE
Add support for array types

### DIFF
--- a/Sources/SwaggerSwift/Functions/getType.swift
+++ b/Sources/SwaggerSwift/Functions/getType.swift
@@ -150,7 +150,8 @@ private func typeOfItems(schema: Schema, items: Node<Items>, typeNamePrefix: Str
     case .reference(let ref):
         let schema = swagger.findSchema(node: .reference(ref))
         if case SchemaType.object = schema.type {
-            return (.object(typeName: ref.components(separatedBy: "/").last!.uppercasingFirst), [])
+            let typeName = ref.components(separatedBy: "/").last!.uppercasingFirst
+            return (.object(typeName: typeName), [])
         } else {
             fatalError()
         }

--- a/Sources/SwaggerSwift/Models/NetworkRequestFunctionResponseType.swift
+++ b/Sources/SwaggerSwift/Models/NetworkRequestFunctionResponseType.swift
@@ -4,7 +4,7 @@ private func toHttpCodeName(code: Int) -> String {
 
 enum NetworkRequestFunctionResponseType {
     case textPlain(HTTPStatusCodes, Bool)
-    case applicationJson(HTTPStatusCodes, Bool, _ typeName: String)
+    case object(HTTPStatusCodes, Bool, _ typeName: String)
     case int(HTTPStatusCodes, Bool)
     case array(HTTPStatusCodes, Bool, _ typeName: String)
     case double(HTTPStatusCodes, Bool)
@@ -17,7 +17,7 @@ enum NetworkRequestFunctionResponseType {
         switch self {
         case .textPlain(let statusCode, _):
             return statusCode
-        case .applicationJson(let statusCode, _, _):
+        case .object(let statusCode, _, _):
             return statusCode
         case .void(let statusCode, _):
             return statusCode
@@ -56,7 +56,7 @@ case \(statusCode.rawValue):
     let result = String(data: data, encoding: .utf8) ?? ""
     completionHandler(.\(swiftResult)(\(resultType("result", resultIsEnum))))
 """
-        case .applicationJson(let statusCode, let resultIsEnum, let responseType):
+        case .object(let statusCode, let resultIsEnum, let responseType):
             return """
 case \(statusCode.rawValue):
     do {

--- a/Sources/SwaggerSwift/SwaggerFileParser/SwaggerFileParser.swift
+++ b/Sources/SwaggerSwift/SwaggerFileParser/SwaggerFileParser.swift
@@ -38,7 +38,10 @@ struct SwaggerFileParser {
                     fatalError("Failed to download Swagger from: \(request.url?.absoluteString ?? "")")
                 }
 
-                files.append(String(data: data!, encoding: .utf8)!)
+                if let data = data {
+                    files.append(String(data: data, encoding: .utf8)!)
+                }
+
                 dispatchGroup.leave()
             }.resume()
         }

--- a/Sources/SwaggerSwift/parseOperation.swift
+++ b/Sources/SwaggerSwift/parseOperation.swift
@@ -175,7 +175,7 @@ func parse(operation: SwaggerSwiftML.Operation, httpMethod: HTTPMethod, serviceP
                     fatalError("Unsupported type inside array: \(type)")
                 }
             case .object(typeName: let typeName):
-                return NetworkRequestFunctionResponseType.applicationJson($0.0, $0.0.isSuccess ? successResponses.count > 1 : errorResponses.count > 1, typeName)
+                return NetworkRequestFunctionResponseType.object($0.0, $0.0.isSuccess ? successResponses.count > 1 : errorResponses.count > 1, typeName)
             case .void:
                 return NetworkRequestFunctionResponseType.void($0.0, $0.0.isSuccess ? successResponses.count > 1 : errorResponses.count > 1)
             case .date:

--- a/Sources/SwaggerSwift/parseOperation.swift
+++ b/Sources/SwaggerSwift/parseOperation.swift
@@ -147,7 +147,6 @@ func parse(operation: SwaggerSwiftML.Operation, httpMethod: HTTPMethod, serviceP
         fatalError("[ERROR] No provided consumer for function \(httpMethod.rawValue) \(servicePath)")
     }
 
-
     let errorResponses = responseTypes.filter { !$0.0.isSuccess }
     let successResponses = responseTypes.filter { $0.0.isSuccess }
 
@@ -169,8 +168,12 @@ func parse(operation: SwaggerSwiftML.Operation, httpMethod: HTTPMethod, serviceP
                 return NetworkRequestFunctionResponseType.boolean(statusCode, isSuccessResponse)
             case .int64:
                 return NetworkRequestFunctionResponseType.int64(statusCode, isSuccessResponse)
-            case .array:
-                fatalError("not supported")
+            case .array(let type):
+                if case .object(let typeName) = type {
+                    return NetworkRequestFunctionResponseType.array($0.0, $0.0.isSuccess ? successResponses.count > 1 : errorResponses.count > 1, typeName)
+                } else {
+                    fatalError("Unsupported type inside array: \(type)")
+                }
             case .object(typeName: let typeName):
                 return NetworkRequestFunctionResponseType.applicationJson($0.0, $0.0.isSuccess ? successResponses.count > 1 : errorResponses.count > 1, typeName)
             case .void:

--- a/Sources/SwaggerSwift/parseRequest.swift
+++ b/Sources/SwaggerSwift/parseRequest.swift
@@ -3,7 +3,6 @@ import SwaggerSwiftML
 func parse(request requestNode: Node<Response>, httpMethod: HTTPMethod, servicePath: String, statusCode: Int, swagger: Swagger) -> (TypeType, [ModelDefinition]) {
     let prefix = "\(servicePath.replacingOccurrences(of: "{", with: "").replacingOccurrences(of: "}", with: "").components(separatedBy: "/").map { $0.components(separatedBy: "-") }.flatMap { $0 }.map { $0.uppercasingFirst }.joined().capitalizingFirstLetter())\(statusCode)"
 
-
     let request: Response
     switch requestNode {
     case .reference(let ref):

--- a/Sources/SwaggerSwift/parseSwagger.swift
+++ b/Sources/SwaggerSwift/parseSwagger.swift
@@ -8,8 +8,12 @@ func parse(swagger: Swagger, swaggerFile: SwaggerFile) -> ServiceDefinition {
     let functions = result.flatMap { $0.0 }
     let definitions = result.flatMap { $0.1 }
 
-    let builtinDefinitions = swagger.definitions!.map {
-        getType(forSchema: $0.value, typeNamePrefix: $0.key, swagger: swagger).1
+    let builtinDefinitions = swagger.definitions!.map { definition -> [ModelDefinition] in
+        let (_, innerDefinitions) = getType(forSchema: definition.value,
+                                            typeNamePrefix: definition.key,
+                                            swagger: swagger)
+
+        return innerDefinitions
     }.flatMap { $0 }
 
     let builtInResponses: [ModelDefinition] = swagger.responses?.map { response -> [ModelDefinition] in


### PR DESCRIPTION
Adds support for having a response that is an array with a single type inside like:
```
 SomeResponse:
    type: array
    items:
      $ref: '#/definitions/SomeModule'
```

This is still lacking support for actually mapping this type out into a specific type.