### PR TITLE
Support typed dictionary values

### DIFF
--- a/Sources/SwaggerSwift/Functions/getType.swift
+++ b/Sources/SwaggerSwift/Functions/getType.swift
@@ -138,9 +138,12 @@ func getType(forSchema schema: SwaggerSwiftML.Schema, typeNamePrefix: String, sw
         case .reference(_):
             fatalError("not supported")
         case .schema(let schema):
-            return getType(forSchema: schema,
-                           typeNamePrefix: typeNamePrefix,
-                           swagger: swagger)
+            let valueType = getType(forSchema: schema,
+                                    typeNamePrefix: typeNamePrefix,
+                                    swagger: swagger)
+            let valueString = valueType.0.toString(required: true)
+            let valueModelDefinitions = valueType.1
+            return (.object(typeName: "[String: " + valueString + "]"), valueModelDefinitions)
         }
     case .file:
         return (.void, [])


### PR DESCRIPTION
This PR adds support for dictionary values with schemas. Consider the following schema for a property.

```
accountMap:
  type: object
    additionalProperties:
      type: string
    example:
      lunarBankAccountId1: billyAccountId1
      lunarBankAccountId2: billyAccountId2
      lunarBankAccountId3: billyAccountId3
```

Before this PR we would generate the following code for this property:

```swift
extension LunarWayBillysBillingAPI {
    public struct PostSettings: Codable {
        public let accountMap: String

        public init(accountMap: String) {
            self.accountMap = accountMap
        }
    }
}
```

However, accountMap is not defined as a string. It's defined as an object (nay, dictionary) where the values are strings. With this PR we're instead generating this code:

```swift
extension LunarWayBillysBillingAPI {
    public struct PostSettings: Codable {
        public let accountMap: [String: String]

        public init(accountMap: [String: String]) {
            self.accountMap = accountMap
        }
    }
}
```

🚨 This PR will break code generated for [lunar-way-credit-application-flow-service](https://github.com/lunarway/lunar-way-credit-application-flow-service). That code currently has properties defined with the type `[String: AdditionalProperty]?` but with this PR it's instead generated with the type `[String: [String: AdditionalProperty]]?`.

Assuming we actually want `[String: AdditionalProperty]?`, I think this is an error in [the Swagger file in the service](https://github.com/lunarway/lunar-way-credit-application-flow-service/blob/master/api/swagger.yaml). The property is defined as:

```
data:
  type: object
  additionalProperties:
    type: object
```

As far as I can understand in [Swagger's documentation](https://swagger.io/docs/specification/data-models/dictionaries/) that's expected to be a nested dictionary.