### PR TITLE
Adding support for dots in model names

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,10 @@ let package = Package(
         .target(
             name: "SwaggerSwift", dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "SwaggerSwiftML", package: "SwaggerSwiftML"),
+                .product(name: "SwaggerSwiftML", package: "SwaggerSwiftML")
             ]),
         .testTarget(
             name: "SwaggerSwiftTests",
-            dependencies: ["SwaggerSwift"]),
+            dependencies: ["SwaggerSwift"])
     ]
 )

--- a/Sources/SwaggerSwift/Functions/getFunctionParameters.swift
+++ b/Sources/SwaggerSwift/Functions/getFunctionParameters.swift
@@ -215,8 +215,14 @@ private func createResultEnumType(types: [(HTTPStatusCodes, TypeType)], failure:
 
         return (typeName, [enumeration])
     } else if filteredTypes.count == 1 {
-        return (filteredTypes[0].1.toString(required: true), [])
+        return (filteredTypes[0].1.toString(required: true).modelNamed, [])
     } else {
         return ("Void", [])
+    }
+}
+
+extension String {
+    var modelNamed: String {
+        return self.uppercasingFirst.replacingOccurrences(of: ".", with: "").replacingOccurrences(of: "-", with: "").replacingOccurrences(of: "_", with: "")
     }
 }

--- a/Sources/SwaggerSwift/Functions/getFunctionParameters.swift
+++ b/Sources/SwaggerSwift/Functions/getFunctionParameters.swift
@@ -41,7 +41,6 @@ func getFunctionParameters(_ parameters: [Parameter], functionName: String, isIn
 
             resolvedModelDefinitions.append(contentsOf: resultType.1)
 
-
             return ModelField(description: nil,
                               type: resultType.0,
                               name: name,
@@ -223,6 +222,10 @@ private func createResultEnumType(types: [(HTTPStatusCodes, TypeType)], failure:
 
 extension String {
     var modelNamed: String {
-        return self.uppercasingFirst.replacingOccurrences(of: ".", with: "").replacingOccurrences(of: "-", with: "").replacingOccurrences(of: "_", with: "")
+        self
+            .split(separator: ".").map { String($0).uppercasingFirst }.joined()
+            .split(separator: "-").map { String($0).uppercasingFirst }.joined()
+            .split(separator: "_").map { String($0).uppercasingFirst }.joined()
+            .uppercasingFirst
     }
 }

--- a/Sources/SwaggerSwift/Functions/getType.swift
+++ b/Sources/SwaggerSwift/Functions/getType.swift
@@ -53,7 +53,7 @@ func getType(forSchema schema: SwaggerSwiftML.Schema, typeNamePrefix: String, sw
         } else {
             return (.string, [])
         }
-    case .integer(let format,_,_,_,_,_):
+    case .integer(let format, _, _, _, _, _):
         if let format = format {
             switch format {
             case .long:
@@ -141,7 +141,7 @@ func getType(forSchema schema: SwaggerSwiftML.Schema, typeNamePrefix: String, sw
         switch valueType {
         case .any:
             return (.object(typeName: "[String: AdditionalProperty]"), [])
-        case .reference(_):
+        case .reference:
             fatalError("not supported")
         case .schema(let schema):
             let valueType = getType(forSchema: schema,
@@ -164,7 +164,7 @@ private func typeOfItems(schema: Schema, items: Node<Items>, typeNamePrefix: Str
         let schema = swagger.findSchema(node: .reference(ref))
         if case SchemaType.object = schema.type {
             let typeName = ref.components(separatedBy: "/").last!.modelNamed
-            
+
             return (.object(typeName: typeName), [])
         } else {
             fatalError()

--- a/Sources/SwaggerSwift/Functions/getType.swift
+++ b/Sources/SwaggerSwift/Functions/getType.swift
@@ -46,7 +46,8 @@ func getType(forSchema schema: SwaggerSwiftML.Schema, typeNamePrefix: String, sw
                 case "uri":
                     return (.object(typeName: "URL"), [])
                 default:
-                    fatalError("🔥 \(swagger.serviceName): Found unsupported field: '\(unsupported)'")
+                    print("⚠️ \(swagger.serviceName): SwaggerSwift does not support '\(unsupported)' for strings", to: &stderr)
+                    return (.object(typeName: "String"), [])
                 }
             }
         } else {
@@ -68,7 +69,8 @@ func getType(forSchema schema: SwaggerSwiftML.Schema, typeNamePrefix: String, sw
             case .byte: fallthrough
             case .binary: fallthrough
             case .boolean:
-                fatalError("This cannot happen for this case")
+                print("⚠️ \(swagger.serviceName): SwaggerSwift does not support '\(format.toString)' for ints", to: &stderr)
+                return (.int, [])
             case .unsupported(let unsupported):
                 switch unsupported {
                 case "int":
@@ -78,7 +80,8 @@ func getType(forSchema schema: SwaggerSwiftML.Schema, typeNamePrefix: String, sw
                 case "decimal":
                     return (.double, [])
                 default:
-                    fatalError("Unsupported field type received: \(unsupported)")
+                    print("⚠️ \(swagger.serviceName): SwaggerSwift does not support '\(unsupported)' for ints", to: &stderr)
+                    return (.int, [])
                 }
             }
         }
@@ -100,7 +103,8 @@ func getType(forSchema schema: SwaggerSwiftML.Schema, typeNamePrefix: String, sw
             case .byte: fallthrough
             case .binary: fallthrough
             case .boolean:
-                fatalError("This cannot happen for this case")
+                print("⚠️ \(swagger.serviceName): SwaggerSwift does not support '\(format.toString)' for number", to: &stderr)
+                return (.double, [])
             case .unsupported(let unsupported):
                 switch unsupported {
                 case "int", "integer":
@@ -110,7 +114,8 @@ func getType(forSchema schema: SwaggerSwiftML.Schema, typeNamePrefix: String, sw
                 case "decimal":
                     return (.double, [])
                 default:
-                    fatalError("Unsupported field type received: \(unsupported)")
+                    print("⚠️ \(swagger.serviceName): SwaggerSwift does not support '\(unsupported)' for number", to: &stderr)
+                    return (.double, [])
                 }
             }
         }
@@ -158,7 +163,8 @@ private func typeOfItems(schema: Schema, items: Node<Items>, typeNamePrefix: Str
     case .reference(let ref):
         let schema = swagger.findSchema(node: .reference(ref))
         if case SchemaType.object = schema.type {
-            let typeName = ref.components(separatedBy: "/").last!.uppercasingFirst
+            let typeName = ref.components(separatedBy: "/").last!.modelNamed
+            
             return (.object(typeName: typeName), [])
         } else {
             fatalError()

--- a/Sources/SwaggerSwift/Functions/parseObject.swift
+++ b/Sources/SwaggerSwift/Functions/parseObject.swift
@@ -7,7 +7,7 @@ private struct AllOfPart {
 }
 
 func parseObject(required: [String], properties: [String: Node<Schema>], allOf: [Node<Schema>]?, swagger: Swagger, typeNamePrefix: String, schema: Schema, customFields: [String: String]) -> (TypeType, [ModelDefinition]) {
-    let typeName = (customFields["x-override-name"] ?? schema.overridesName ?? typeNamePrefix).uppercasingFirst
+    let typeName = (customFields["x-override-name"] ?? schema.overridesName ?? typeNamePrefix).modelNamed
 
     if let allOf = allOf {
         let allOfParts: [AllOfPart] = allOf.map {
@@ -82,6 +82,8 @@ func parseObject(required: [String], properties: [String: Node<Schema>], allOf: 
                 typeName = "\(typeName)\(propertyName.uppercasingFirst)"
             }
 
+            typeName = typeName.modelNamed
+
             if case SchemaType.object = node.type {
                 return (ModelField(description: node.description,
                                    type: .object(typeName: typeName),
@@ -99,6 +101,8 @@ func parseObject(required: [String], properties: [String: Node<Schema>], allOf: 
             if typeName == "Type" {
                 typeName = "\(typeName)\(propertyName.uppercasingFirst)"
             }
+
+            typeName = typeName.modelNamed
 
             let (type, embeddedDefinitions) = getType(forSchema: innerSchema,
                                                       typeNamePrefix: typeName,

--- a/Sources/SwaggerSwift/Models/Enumeration.swift
+++ b/Sources/SwaggerSwift/Models/Enumeration.swift
@@ -65,7 +65,6 @@ public init(from decoder: Decoder) throws {
 
 """.indentLines(1)
 
-
             let encodeCases = values.sorted().map {
                 """
 case .\(Self.toCasename($0, isCodable)):
@@ -162,7 +161,7 @@ extension String {
     }
 }
 
-extension String  {
+extension String {
     var isNumber: Bool {
         return !isEmpty && rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil
     }

--- a/Sources/SwaggerSwift/Models/NetworkRequestFunctionResponseType.swift
+++ b/Sources/SwaggerSwift/Models/NetworkRequestFunctionResponseType.swift
@@ -62,7 +62,7 @@ case \(statusCode.rawValue):
     do {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom(dateDecodingStrategy)
-        let result = try decoder.decode(\(responseType).self, from: data)
+        let result = try decoder.decode(\(responseType.modelNamed).self, from: data)
 
         completionHandler(.\(swiftResult)(\(resultType("result", resultIsEnum))))
     } catch let error {

--- a/Sources/SwaggerSwift/Utilities/String+Utils.swift
+++ b/Sources/SwaggerSwift/Utilities/String+Utils.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-fileprivate let badChars = CharacterSet.alphanumerics.inverted
+private let badChars = CharacterSet.alphanumerics.inverted
 
 extension String {
     func capitalizingFirstLetter() -> String {

--- a/Sources/SwaggerSwift/main.swift
+++ b/Sources/SwaggerSwift/main.swift
@@ -15,7 +15,7 @@ struct SwaggerSwiftParser: ParsableCommand {
 
     @Argument(help: "GitHub token")
     var gitHubToken: String
-    
+
     @Option(name: .shortAndLong, help: "List of APIs to generate, e.g. --api-list lunar-way-onboarding-service", transform: { (arg: String) in
         arg.split(separator: ",").map(String.init)
     })

--- a/Sources/SwaggerSwift/parseOperation.swift
+++ b/Sources/SwaggerSwift/parseOperation.swift
@@ -42,7 +42,7 @@ func parse(operation: SwaggerSwiftML.Operation, httpMethod: HTTPMethod, serviceP
                          servicePath: servicePath,
                          statusCode: $0.key,
                          swagger: swagger)
-        
+
         let statusCode = HTTPStatusCodes(rawValue: $0.key)!
         return (statusCode, type.0, type.1)
     }
@@ -61,7 +61,7 @@ func parse(operation: SwaggerSwiftML.Operation, httpMethod: HTTPMethod, serviceP
                                                          responseTypes: resTypes,
                                                          swagger: swagger,
                                                          swaggerFile: swaggerFile)
-    
+
     let functionParameters = functionParametersResult.0
     definitions.append(contentsOf: functionParametersResult.1)
 
@@ -99,7 +99,7 @@ func parse(operation: SwaggerSwiftML.Operation, httpMethod: HTTPMethod, serviceP
                             return QueryElement(fieldName: $0.name, fieldValue: $0.name.camelized, isOptional: $0.required == false, isEnum: isEnum)
                         case .email:
                             return QueryElement(fieldName: $0.name, fieldValue: $0.name.camelized, isOptional: $0.required == false, isEnum: isEnum)
-                        case .unsupported(_):
+                        case .unsupported:
                             return QueryElement(fieldName: $0.name, fieldValue: $0.name.camelized, isOptional: $0.required == false, isEnum: isEnum)
                         }
                     } else {

--- a/Sources/SwaggerSwift/parseSwagger.swift
+++ b/Sources/SwaggerSwift/parseSwagger.swift
@@ -48,7 +48,7 @@ func parse(swagger: Swagger, swaggerFile: SwaggerFile, verbose: Bool) -> Service
                      required: true,
                      typeIsAutoclosure: true,
                      typeIsBlock: true,
-                     defaultValue: nil),
+                     defaultValue: nil)
     ]
 
     if hasGlobalHeaders {

--- a/Tests/SwaggerSwiftTests/SwaggerSwiftTests.swift
+++ b/Tests/SwaggerSwiftTests/SwaggerSwiftTests.swift
@@ -9,6 +9,6 @@ final class SwaggerSwiftTests: XCTestCase {
     }
 
     static var allTests = [
-        ("testExample", testExample),
+        ("testExample", testExample)
     ]
 }

--- a/Tests/SwaggerSwiftTests/XCTestManifests.swift
+++ b/Tests/SwaggerSwiftTests/XCTestManifests.swift
@@ -3,7 +3,7 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(SwaggerSwiftTests.allTests),
+        testCase(SwaggerSwiftTests.allTests)
     ]
 }
 #endif


### PR DESCRIPTION
This supports the case where someone calls their model something like: `Response.MyType.Whatever`

Also added better error handling