### PR TITLE
Bugfix - Dashes in service names

### DIFF
--- a/Sources/SwaggerSwift/Extensions/Swagger+Extensions.swift
+++ b/Sources/SwaggerSwift/Extensions/Swagger+Extensions.swift
@@ -4,7 +4,7 @@ import SwaggerSwiftML
 extension Swagger {
     /// The name of the service the Swagger file exposes
     var serviceName: String {
-        info.title.components(separatedBy: CharacterSet.whitespaces).map { $0.uppercasingFirst }.joined()
+        info.title.components(separatedBy: CharacterSet.whitespaces.union(CharacterSet(charactersIn: "-"))).map { $0.uppercasingFirst }.joined()
     }
 
     func findParameter(node: Node<Parameter>) -> Parameter {


### PR DESCRIPTION
Fixes an issue where a service named e.g. term-deposit in swagger results in generated types named Term-depositAPI instead of TermDepositAPI 😢 