### PR TITLE
Fix Error: Would embed objects of referenced types no matter what

### DIFF
--- a/Sources/SwaggerSwift/Functions/getType.swift
+++ b/Sources/SwaggerSwift/Functions/getType.swift
@@ -4,7 +4,7 @@ func getType(forSchema schema: SwaggerSwiftML.Schema, typeNamePrefix: String, sw
     switch schema.type {
     case .string(format: let format, let enumValues, _, _, _):
         if let enumValues = enumValues {
-            let enumTypename = typeNamePrefix
+            let enumTypename = typeNamePrefix.modelNamed
             let def = ModelDefinition.enumeration(Enumeration(serviceName: swagger.serviceName,
                                                               description: schema.description,
                                                               typeName: enumTypename,

--- a/Sources/SwaggerSwift/Functions/parseObject.swift
+++ b/Sources/SwaggerSwift/Functions/parseObject.swift
@@ -90,11 +90,12 @@ func parseObject(required: [String], properties: [String: Node<Schema>], allOf: 
                                    name: propertyName,
                                    required: schema.required.contains(propertyName)), [])
             } else {
-                let (type, embeddedDefinitions) = getType(forSchema: node, typeNamePrefix: typeName, swagger: swagger)
-                return (ModelField(description: node.description,
-                                   type: type,
-                                   name: propertyName,
-                                   required: schema.required.contains(propertyName)), embeddedDefinitions)
+                // since it is a referenced object we dont care about the embedded definitions as they are parsed elsewhere
+                let (type, _) = getType(forSchema: node, typeNamePrefix: typeName, swagger: swagger)
+                    return (ModelField(description: node.description,
+                                       type: type,
+                                       name: propertyName,
+                                       required: schema.required.contains(propertyName)), [])
             }
         case .node(let innerSchema):
             var typeName = "\(propertyName.uppercasingFirst)"

--- a/Sources/SwaggerSwift/parseOperation.swift
+++ b/Sources/SwaggerSwift/parseOperation.swift
@@ -19,7 +19,7 @@ func parse(operation: SwaggerSwiftML.Operation, httpMethod: HTTPMethod, serviceP
 
     var functionName: String
     if let overrideName = operation.operationId {
-        functionName = overrideName
+        functionName = overrideName.lowercasingFirst
     } else {
         functionName = httpMethod.rawValue + servicePath
             .replacingOccurrences(of: "{", with: "")


### PR DESCRIPTION
If an object had a property that was referenced e.g.
```
Cake:
  properties:
    cakeNumber:
      $ref: "CakeNumberType"
```

it would copy CakeNumberType into Cake, as well as generating a global object. This makes sure that the global object is always used.