### PR TITLE
Fix: Newline in description would cause un-escaped newline in Swift

### DIFF
--- a/Sources/SwaggerSwift/Models/ModelField.swift
+++ b/Sources/SwaggerSwift/Models/ModelField.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Represents a single field on a Model
 struct ModelField {
     let description: String?
@@ -40,7 +42,7 @@ extension ModelField {
         let declaration = "public let \(safePropertyName): \(type.toString(required: required || defaultValue != nil))"
         if let desc = description {
             return """
-// \(desc)
+\(desc.components(separatedBy: "\n").filter { $0.isEmpty == false }.map { "// \($0)" }.joined(separator: "\n").trimmingCharacters(in: CharacterSet.whitespacesAndNewlines))
 \(declaration)
 """
         } else {


### PR DESCRIPTION
If there are a new line in a description it would look like this:

```
        // a lot of text-a lot of text-a lot of text-a lot of text-a lot of text-a lot of text-a lot of text
more text in description here that isn't handled
        public let amount: Double
```

this PR makes it so it looks like this:

```
        // a lot of text-a lot of text-a lot of text-a lot of text-a lot of text-a lot of text-a lot of text
        // more text in description here that isn't handled
        public let amount: Double
```

