### PR TITLE
Xcode 13.3 throws a warning when using `self`

### DIFF
--- a/Sources/SwaggerSwift/Models/GlobalHeadersModel.swift
+++ b/Sources/SwaggerSwift/Models/GlobalHeadersModel.swift
@@ -24,7 +24,7 @@ struct GlobalHeadersModel {
 
             let fieldType = "\(field.type.toString(required: field.required || field.defaultValue != nil))"
 
-            if field.needsArgumentLabel {
+            if field.isNamedAfterSwiftKeyword {
                 return "\(field.argumentLabel) \(field.safeParameterName): \(fieldType)\(defaultArg)"
             } else {
                 return "\(field.safeParameterName): \(fieldType)\(defaultArg)"

--- a/Sources/SwaggerSwift/Models/ModelField.swift
+++ b/Sources/SwaggerSwift/Models/ModelField.swift
@@ -9,7 +9,7 @@ struct ModelField {
     let safePropertyName: SafePropertyName
     let safeParameterName: SafeParameterName
     let defaultValue: String?
-    var needsArgumentLabel: Bool {
+    var isNamedAfterSwiftKeyword: Bool {
         return argumentLabel != safeParameterName.value
     }
 
@@ -20,6 +20,7 @@ struct ModelField {
         self.safePropertyName = SafePropertyName(name)
         self.safeParameterName = SafeParameterName(name)
         self.required = required
+
         switch type {
         case .boolean(let defaultValue):
             if let defaultValue = defaultValue {

--- a/Sources/SwaggerSwift/Models/SafeParameterName.swift
+++ b/Sources/SwaggerSwift/Models/SafeParameterName.swift
@@ -5,7 +5,7 @@ struct SafeParameterName: Equatable, Hashable {
 
     init(_ parameterName: String) {
         if SwiftKeyword(rawValue: parameterName) != nil {
-            value = "_swaggerswift_" + parameterName
+            value = "_\(parameterName)"
         } else {
             value = parameterName
         }

--- a/Sources/SwaggerSwift/Models/SafePropertyName.swift
+++ b/Sources/SwaggerSwift/Models/SafePropertyName.swift
@@ -4,8 +4,8 @@ struct SafePropertyName: Equatable, Hashable {
     let value: String
 
     init(_ propertyName: String) {
-        if SwiftKeyword(rawValue: propertyName) != nil {
-            value = "`" + propertyName + "`"
+        if let keyword = SwiftKeyword(rawValue: propertyName) {
+            value = keyword.safePropertyName
         } else {
             value = propertyName
         }

--- a/Sources/SwaggerSwift/Models/SwiftKeyword.swift
+++ b/Sources/SwaggerSwift/Models/SwiftKeyword.swift
@@ -3,14 +3,39 @@ import Foundation
 /// The SwiftKeyword type is used when ensuring that properties and parameters don't have the same name as a keyword.
 /// The list is not complete.
 enum SwiftKeyword: String {
-    case `continue`
-    case `operator`
-    case `self`
-    case `private`
-    case `public`
-    case `throw`
-    case `throws`
-    case `override`
-    case `default`
-    case `defer`
+    case kContinue = "continue"
+    case kOperator = "operator"
+    case kSelf = "self"
+    case kPrivate = "private"
+    case kPublic = "public"
+    case kThrow = "throw"
+    case kThrows = "throws"
+    case kOverride = "override"
+    case kDefault = "default"
+    case kDefer = "defer"
+
+    var safePropertyName: String {
+        switch self {
+        case .kContinue:
+            return "`continue`"
+        case .kOperator:
+            return "`operator`"
+        case .kSelf:
+            return "_self"
+        case .kPrivate:
+            return "`private`"
+        case .kPublic:
+            return "`public`"
+        case .kThrow:
+            return "`throw`"
+        case .kThrows:
+            return "`throws`"
+        case .kOverride:
+            return "`override`"
+        case .kDefault:
+            return "`default`"
+        case .kDefer:
+            return "`defer`"
+        }
+    }
 }


### PR DESCRIPTION
Instead self will now become _self