### PR TITLE
Add custom file path for swagger files

### DIFF
--- a/Sources/SwaggerSwift/SwaggerFileParser/Models/Service.swift
+++ b/Sources/SwaggerSwift/SwaggerFileParser/Models/Service.swift
@@ -1,3 +1,4 @@
 struct Service: Decodable {
     let branch: String?
+    let swaggerFilePath: String?
 }

--- a/Sources/SwaggerSwift/SwaggerFileParser/SwaggerFileParser.swift
+++ b/Sources/SwaggerSwift/SwaggerFileParser/SwaggerFileParser.swift
@@ -42,7 +42,7 @@ struct SwaggerFileParser {
         let services = swaggerFile.services.filter { apiList?.contains($0.key) ?? true }
 
         let requests = services.map { service -> (branch: String?, serviceName: String, request: URLRequest) in
-            let url = URL(string: "https://raw.githubusercontent.com/\(swaggerFile.organisation)/\(service.key)/\(service.value.branch ?? "master")/\(swaggerFile.path)")!
+            let url = URL(string: "https://raw.githubusercontent.com/\(swaggerFile.organisation)/\(service.key)/\(service.value.branch ?? "master")/\(service.value.swaggerFilePath ?? swaggerFile.path)")!
             if verbose {
                 print("Downloading Swagger at: \(url.absoluteString)", to: &stdout)
             }


### PR DESCRIPTION
Makes it possible to define a custom file path that overrides the global path:

```
...
serviceName: {. swaggerFilePath: <path> }
...
```