### PR TITLE
Better URL management (2/2): URL decoding from String initialisation

### DIFF
--- a/Sources/SwaggerSwiftCore/Models/Model.swift
+++ b/Sources/SwaggerSwiftCore/Models/Model.swift
@@ -10,15 +10,15 @@ struct Model {
     let isInternalOnly: Bool
     let embeddedDefinitions: [ModelDefinition]
     let isCodable: Bool
-    
+
     func resolveInherits(_ definitions: [Model]) -> Model {
         let inherits = inheritsFrom.compactMap { definitionName in
             definitions.first(where: { $0.typeName == definitionName })
         }
-        
+
         let inheritedFields = inherits.flatMap { $0.fields }
         let inheritedEmbeddedDefinitions = inherits.flatMap { $0.embeddedDefinitions }
-        
+
         return Model(description: description,
                      typeName: typeName,
                      fields: (fields + inheritedFields).sorted(by: { $0.safePropertyName < $1.safePropertyName }),
@@ -27,7 +27,7 @@ struct Model {
                      embeddedDefinitions: embeddedDefinitions + inheritedEmbeddedDefinitions,
                      isCodable: isCodable)
     }
-    
+
     func modelDefinition(serviceName: String?, swaggerFile: SwaggerFile) -> String {
         let comment: String?
         if let description = description {
@@ -37,7 +37,7 @@ struct Model {
         } else {
             comment = nil
         }
-        
+
         let initParameterStrings: [String] = fields.map { field in
             let defaultArg: String
             if let defaultValue = field.defaultValue {
@@ -45,75 +45,75 @@ struct Model {
             } else {
                 defaultArg = ""
             }
-            
+
             let fieldType = "\(field.type.toString(required: field.required || field.defaultValue != nil))"
-            
+
             if field.isNamedAfterSwiftKeyword {
                 return "\(field.argumentLabel) \(field.safeParameterName): \(fieldType)\(defaultArg)"
             } else {
                 return "\(field.safeParameterName): \(fieldType)\(defaultArg)"
             }
         }
-        
+
         let initMethod = """
 public init(\(initParameterStrings.joined(separator: ", "))) {
     \(fields.map { "self.\($0.safePropertyName) = \($0.safeParameterName)" }.joined(separator: "\n    "))
 }
 """
-        
+
         let modelFields = fields.sorted(by: { $0.safePropertyName < $1.safePropertyName }).flatMap { $0.toSwift.split(separator: "\n") }
-        
+
         var model = ""
-        
+
         if let comment = comment {
             model += comment + "\n"
         }
-        
+
         model += "public struct \(typeName)\(isCodable ? ": Codable" : "") {\n"
-        
+
         model += modelFields.map { $0 }.joined(separator: "\n").indentLines(1)
-        
+
         model += "\n\n" + initMethod.indentLines(1)
-        
+
         let fieldIsNamedAfterKeyword = fields.contains(where: { $0.isNamedAfterSwiftKeyword })
         let fieldHasDefaultValue = fields.contains(where: { $0.defaultValue != nil })
         let fieldHasOptionalURL = fields.contains(where: { $0.type.toString(required: true) == "URL" && !$0.required })
-        
+
         if isCodable && (fieldIsNamedAfterKeyword || fieldHasDefaultValue || fieldHasOptionalURL) {
             model += "\n\n"
             model += encodeFunction().indentLines(1)
         }
-        
+
         if isCodable && fieldIsNamedAfterKeyword {
             model += "\n\n"
             model += codingKeysFunction().indentLines(1)
         }
-        
+
         if embeddedDefinitions.count > 0 {
             model += "\n\n"
         }
-        
+
         model += embeddedDefinitions
             .sorted(by: { $0.typeName < $1.typeName })
             .map { $0.toSwift(serviceName: serviceName, swaggerFile: swaggerFile, embedded: true, packagesToImport: []) }
             .joined(separator: "\n\n")
             .indentLines(1)
-        
+
         model += "\n}"
-        
+
         return model
     }
-    
+
     private func codingKeysFunction() -> String {
         let cases = fields.map { "case \($0.safeParameterName) = \"\($0.argumentLabel)\"" }.joined(separator: "\n").indentLines(1)
-        
+
         return """
         enum CodingKeys: String, CodingKey {
         \(cases)
         }
         """
     }
-    
+
     private func encodeFunction() -> String {
         let decodeFields = fields.map {
             let variableName = $0.safePropertyName
@@ -124,14 +124,14 @@ public init(\(initParameterStrings.joined(separator: ", "))) {
             } else {
                 decodeIfPresent = ""
             }
-            
+
             let defaultValue: String
             if let defaultValueValue = $0.defaultValue {
                 defaultValue = " ?? \(defaultValueValue)"
             } else {
                 defaultValue = ""
             }
-            
+
             if !$0.required, typeName == "URL" {
                 return """
             // Allows the backend to return badly formatted urls
@@ -145,12 +145,12 @@ public init(\(initParameterStrings.joined(separator: ", "))) {
                 return "self.\(variableName) = try container.decode\(decodeIfPresent)(\(typeName).self, forKey: .\(variableName))\(defaultValue)"
             }
         }.joined(separator: "\n")
-        
+
         let functionBody = """
 let container = try decoder.container(keyedBy: CodingKeys.self)
 \(decodeFields)
 """
-        
+
         return """
 public init(from decoder: Decoder) throws {
 \(functionBody.indentLines(1))
@@ -162,39 +162,39 @@ public init(from decoder: Decoder) throws {
 extension Model: Swiftable {
     func toSwift(serviceName: String?, swaggerFile: SwaggerFile, embedded: Bool, packagesToImport: [String]) -> String {
         precondition(inheritsFrom.count == 0)
-        
+
         let isInExtension = serviceName != nil
-        
+
         if embedded {
             return modelDefinition(serviceName: serviceName, swaggerFile: swaggerFile)
         }
-        
+
         var model = ""
         model.appendLine("import Foundation")
         packagesToImport.forEach { model.appendLine("import \($0)") }
         model.appendLine()
-        
+
         if isInternalOnly {
             model.appendLine("#if DEBUG")
             model.appendLine()
         }
-        
+
         if let serviceName = serviceName {
             model.appendLine("extension \(serviceName) {")
         }
-        
+
         model += modelDefinition(serviceName: serviceName, swaggerFile: swaggerFile).indentLines(isInExtension ? 1 : 0)
-        
+
         if let _ = serviceName {
             model.appendLine()
             model.appendLine("}")
         }
-        
+
         if isInternalOnly {
             model.appendLine()
             model.appendLine("#endif")
         }
-        
+
         return model
     }
 }

--- a/Sources/SwaggerSwiftCore/Models/Model.swift
+++ b/Sources/SwaggerSwiftCore/Models/Model.swift
@@ -10,15 +10,15 @@ struct Model {
     let isInternalOnly: Bool
     let embeddedDefinitions: [ModelDefinition]
     let isCodable: Bool
-
+    
     func resolveInherits(_ definitions: [Model]) -> Model {
         let inherits = inheritsFrom.compactMap { definitionName in
             definitions.first(where: { $0.typeName == definitionName })
         }
-
+        
         let inheritedFields = inherits.flatMap { $0.fields }
         let inheritedEmbeddedDefinitions = inherits.flatMap { $0.embeddedDefinitions }
-
+        
         return Model(description: description,
                      typeName: typeName,
                      fields: (fields + inheritedFields).sorted(by: { $0.safePropertyName < $1.safePropertyName }),
@@ -27,7 +27,7 @@ struct Model {
                      embeddedDefinitions: embeddedDefinitions + inheritedEmbeddedDefinitions,
                      isCodable: isCodable)
     }
-
+    
     func modelDefinition(serviceName: String?, swaggerFile: SwaggerFile) -> String {
         let comment: String?
         if let description = description {
@@ -37,7 +37,7 @@ struct Model {
         } else {
             comment = nil
         }
-
+        
         let initParameterStrings: [String] = fields.map { field in
             let defaultArg: String
             if let defaultValue = field.defaultValue {
@@ -45,74 +45,75 @@ struct Model {
             } else {
                 defaultArg = ""
             }
-
+            
             let fieldType = "\(field.type.toString(required: field.required || field.defaultValue != nil))"
-
+            
             if field.isNamedAfterSwiftKeyword {
                 return "\(field.argumentLabel) \(field.safeParameterName): \(fieldType)\(defaultArg)"
             } else {
                 return "\(field.safeParameterName): \(fieldType)\(defaultArg)"
             }
         }
-
+        
         let initMethod = """
 public init(\(initParameterStrings.joined(separator: ", "))) {
     \(fields.map { "self.\($0.safePropertyName) = \($0.safeParameterName)" }.joined(separator: "\n    "))
 }
 """
-
+        
         let modelFields = fields.sorted(by: { $0.safePropertyName < $1.safePropertyName }).flatMap { $0.toSwift.split(separator: "\n") }
-
+        
         var model = ""
-
+        
         if let comment = comment {
             model += comment + "\n"
         }
-
+        
         model += "public struct \(typeName)\(isCodable ? ": Codable" : "") {\n"
-
+        
         model += modelFields.map { $0 }.joined(separator: "\n").indentLines(1)
-
+        
         model += "\n\n" + initMethod.indentLines(1)
-
+        
         let fieldIsNamedAfterKeyword = fields.contains(where: { $0.isNamedAfterSwiftKeyword })
         let fieldHasDefaultValue = fields.contains(where: { $0.defaultValue != nil })
-
-        if isCodable && (fieldIsNamedAfterKeyword || fieldHasDefaultValue) {
+        let fieldHasURL = fields.contains(where: { $0.type.toString(required: true) == "URL" })
+        
+        if isCodable && (fieldIsNamedAfterKeyword || fieldHasDefaultValue || fieldHasURL) {
             model += "\n\n"
             model += encodeFunction().indentLines(1)
         }
-
+        
         if isCodable && fieldIsNamedAfterKeyword {
             model += "\n\n"
             model += codingKeysFunction().indentLines(1)
         }
-
+        
         if embeddedDefinitions.count > 0 {
             model += "\n\n"
         }
-
+        
         model += embeddedDefinitions
             .sorted(by: { $0.typeName < $1.typeName })
             .map { $0.toSwift(serviceName: serviceName, swaggerFile: swaggerFile, embedded: true, packagesToImport: []) }
             .joined(separator: "\n\n")
             .indentLines(1)
-
+        
         model += "\n}"
-
+        
         return model
     }
-
+    
     private func codingKeysFunction() -> String {
         let cases = fields.map { "case \($0.safeParameterName) = \"\($0.argumentLabel)\"" }.joined(separator: "\n").indentLines(1)
-
+        
         return """
         enum CodingKeys: String, CodingKey {
         \(cases)
         }
         """
     }
-
+    
     private func encodeFunction() -> String {
         let decodeFields = fields.map {
             let variableName = $0.safePropertyName
@@ -123,22 +124,33 @@ public init(\(initParameterStrings.joined(separator: ", "))) {
             } else {
                 decodeIfPresent = ""
             }
-
+            
             let defaultValue: String
             if let defaultValueValue = $0.defaultValue {
                 defaultValue = " ?? \(defaultValueValue)"
             } else {
                 defaultValue = ""
             }
-
-            return "self.\(variableName) = try container.decode\(decodeIfPresent)(\(typeName).self, forKey: .\(variableName))\(defaultValue)"
+            
+            if !$0.required, typeName == "URL" {
+                return """
+            // Allows the backend to return badly formatted urls
+            if let urlString = try container.decode\(decodeIfPresent)(String.self, forKey: .\(variableName))\(defaultValue) {
+                self.\(variableName) = URL(string: urlString)
+            } else {
+                self.\(variableName) = nil
+            }
+            """
+            } else {
+                return "self.\(variableName) = try container.decode\(decodeIfPresent)(\(typeName).self, forKey: .\(variableName))\(defaultValue)"
+            }
         }.joined(separator: "\n")
-
+        
         let functionBody = """
 let container = try decoder.container(keyedBy: CodingKeys.self)
 \(decodeFields)
 """
-
+        
         return """
 public init(from decoder: Decoder) throws {
 \(functionBody.indentLines(1))
@@ -150,39 +162,39 @@ public init(from decoder: Decoder) throws {
 extension Model: Swiftable {
     func toSwift(serviceName: String?, swaggerFile: SwaggerFile, embedded: Bool, packagesToImport: [String]) -> String {
         precondition(inheritsFrom.count == 0)
-
+        
         let isInExtension = serviceName != nil
-
+        
         if embedded {
             return modelDefinition(serviceName: serviceName, swaggerFile: swaggerFile)
         }
-
+        
         var model = ""
         model.appendLine("import Foundation")
         packagesToImport.forEach { model.appendLine("import \($0)") }
         model.appendLine()
-
+        
         if isInternalOnly {
             model.appendLine("#if DEBUG")
             model.appendLine()
         }
-
+        
         if let serviceName = serviceName {
             model.appendLine("extension \(serviceName) {")
         }
-
+        
         model += modelDefinition(serviceName: serviceName, swaggerFile: swaggerFile).indentLines(isInExtension ? 1 : 0)
-
+        
         if let _ = serviceName {
             model.appendLine()
             model.appendLine("}")
         }
-
+        
         if isInternalOnly {
             model.appendLine()
             model.appendLine("#endif")
         }
-
+        
         return model
     }
 }

--- a/Sources/SwaggerSwiftCore/Models/Model.swift
+++ b/Sources/SwaggerSwiftCore/Models/Model.swift
@@ -77,9 +77,9 @@ public init(\(initParameterStrings.joined(separator: ", "))) {
         
         let fieldIsNamedAfterKeyword = fields.contains(where: { $0.isNamedAfterSwiftKeyword })
         let fieldHasDefaultValue = fields.contains(where: { $0.defaultValue != nil })
-        let fieldHasURL = fields.contains(where: { $0.type.toString(required: true) == "URL" })
+        let fieldHasOptionalURL = fields.contains(where: { $0.type.toString(required: true) == "URL" && !$0.required })
         
-        if isCodable && (fieldIsNamedAfterKeyword || fieldHasDefaultValue || fieldHasURL) {
+        if isCodable && (fieldIsNamedAfterKeyword || fieldHasDefaultValue || fieldHasOptionalURL) {
             model += "\n\n"
             model += encodeFunction().indentLines(1)
         }

--- a/Sources/SwaggerSwiftCore/SwaggerFileParser/Models/SwaggerFile.swift
+++ b/Sources/SwaggerSwiftCore/SwaggerFileParser/Models/SwaggerFile.swift
@@ -1,4 +1,5 @@
 struct SwaggerFile: Decodable {
+    
     let path: String
     let organisation: String
     let services: [String: Service]
@@ -9,6 +10,13 @@ struct SwaggerFile: Decodable {
         case organisation
         case services
         case globalHeaders
+    }
+
+    init(path: String, organisation: String, services: [String : Service], globalHeaders: [String]?) {
+        self.path = path
+        self.organisation = organisation
+        self.services = services
+        self.globalHeaders = globalHeaders
     }
 
     init(from decoder: Decoder) throws {

--- a/Tests/SwaggerSwiftCoreTests/SwaggerSwiftCoreTests.swift
+++ b/Tests/SwaggerSwiftCoreTests/SwaggerSwiftCoreTests.swift
@@ -5,7 +5,7 @@ final class SwaggerSwiftTests: XCTestCase {
     
     let swaggerFile = SwaggerFile(path: "", organisation: "", services: [:], globalHeaders: nil)
     
-    func testURLDecodeFormat() {
+    func testOptionalURLDecodeFormat() {
         
         let model = Model(description: nil,
                           typeName: "Test",
@@ -38,8 +38,33 @@ public struct Test: Codable {
 }
 """)
     }
+    
+    func testURLDecodeFormat() {
+        
+        let model = Model(description: nil,
+                          typeName: "Test",
+                          fields: [.init(description: nil, type: .object(typeName: "URL"), name: "url", required: true)],
+                          inheritsFrom: [],
+                          isInternalOnly: false,
+                          embeddedDefinitions: [],
+                          isCodable: true)
+
+        let result = model.modelDefinition(serviceName: nil,
+                                           swaggerFile: swaggerFile)
+
+        XCTAssertEqual(result, """
+public struct Test: Codable {
+    public let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+}
+""")
+    }
 
     static var allTests = [
-        ("testExample", testURLDecodeFormat)
+        ("testOptionalURLDecodeFormat", testOptionalURLDecodeFormat),
+        ("testURLDecodeFormat", testURLDecodeFormat)
     ]
 }

--- a/Tests/SwaggerSwiftCoreTests/SwaggerSwiftCoreTests.swift
+++ b/Tests/SwaggerSwiftCoreTests/SwaggerSwiftCoreTests.swift
@@ -1,14 +1,45 @@
 import XCTest
+@testable import SwaggerSwiftCore
 
-final class SwaggerSwiftCoreTests: XCTestCase {
-    func testExample() {
-//        // This is an example of a functional test case.
-//        // Use XCTAssert and related functions to verify your tests produce the correct
-//        // results.
-//        XCTAssertEqual(SwaggerSwift().text, "Hello, World!")
+final class SwaggerSwiftTests: XCTestCase {
+    
+    let swaggerFile = SwaggerFile(path: "", organisation: "", services: [:], globalHeaders: nil)
+    
+    func testURLDecodeFormat() {
+        
+        let model = Model(description: nil,
+                          typeName: "Test",
+                          fields: [.init(description: nil, type: .object(typeName: "URL"), name: "url", required: false)],
+                          inheritsFrom: [],
+                          isInternalOnly: false,
+                          embeddedDefinitions: [],
+                          isCodable: true)
+
+        let result = model.modelDefinition(serviceName: nil,
+                                           swaggerFile: swaggerFile)
+
+        XCTAssertEqual(result, """
+public struct Test: Codable {
+    public let url: URL?
+
+    public init(url: URL?) {
+        self.url = url
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Allows the backend to return badly formatted urls
+        if let urlString = try container.decodeIfPresent(String.self, forKey: .url) {
+            self.url = URL(string: urlString)
+        } else {
+            self.url = nil
+        }
+    }
+}
+""")
     }
 
     static var allTests = [
-        ("testExample", testExample)
+        ("testExample", testURLDecodeFormat)
     ]
 }


### PR DESCRIPTION
Whenever the backend serves us a URL, we should be able to decode it as such. 
However, some endpoints serves empty URLs as `""` (empty string) instead of `null`.
`init(from decoder: Decoder)` will fail trying to decode an empty string as `Optional<URL>`, so in this PR, the main focus is to decode URL's as strings, and assign them using the `URL(string: )` initialiser instead.
This will only apply if the URL to be decoded is an optional.
