### PR TITLE
:bug: Fix error where capital letter in service path variable wouldnt match param

### DIFF
--- a/Sources/SwaggerSwiftCore/Models/NetworkRequestFunction.swift
+++ b/Sources/SwaggerSwiftCore/Models/NetworkRequestFunction.swift
@@ -48,9 +48,17 @@ extension NetworkRequestFunction: Swiftable {
     func toSwift(serviceName: String?, swaggerFile: SwaggerFile, embedded: Bool, packagesToImport: [String]) -> String {
         let arguments = parameters.map { "\($0.name.variableNameFormatted): \($0.typeName.toString(required: $0.required))" }.joined(separator: ", ")
 
-        let servicePath = self.servicePath
-            .replacingOccurrences(of: "{", with: "\\(")
-            .replacingOccurrences(of: "}", with: ")")
+        let servicePath = self.servicePath.split(separator: "/").map {
+            let path = String($0)
+                .replacingOccurrences(of: "{", with: "")
+                .replacingOccurrences(of: "}", with: "")
+
+            if $0.contains("{") {
+                return "\\(\(path.variableNameFormatted))"
+            } else {
+                return path
+            }
+        }.joined(separator: "/")
 
         let queryStatement: String
         if queries.count > 0 {

--- a/Sources/SwaggerSwiftCore/parseOperation.swift
+++ b/Sources/SwaggerSwiftCore/parseOperation.swift
@@ -30,7 +30,6 @@ func parse(operation: SwaggerSwiftML.Operation, httpMethod: HTTPMethod, serviceP
             .replacingOccurrences(of: "{", with: "")
             .replacingOccurrences(of: "}", with: "")
             .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "-", with: "_")
             .split(separator: "_")
             .map { String($0).uppercasingFirst }


### PR DESCRIPTION
If you take a service path such as `path/{Param}` it would be converted to `path/\(Param)`, however the function parameter is variable formatted, so this PR changes it so that the result is: `path/\(param)`