### PR TITLE
Use consistent path name

### DIFF
--- a/Sources/SwaggerSwiftCore/SwaggerFileParser/Models/Service.swift
+++ b/Sources/SwaggerSwiftCore/SwaggerFileParser/Models/Service.swift
@@ -1,4 +1,4 @@
 struct Service: Decodable {
     let branch: String?
-    let swaggerFilePath: String?
+    let path: String?
 }

--- a/Sources/SwaggerSwiftCore/SwaggerFileParser/SwaggerFileParser.swift
+++ b/Sources/SwaggerSwiftCore/SwaggerFileParser/SwaggerFileParser.swift
@@ -42,7 +42,7 @@ struct SwaggerFileParser {
         let services = swaggerFile.services.filter { apiList?.contains($0.key) ?? true }
 
         let requests = services.map { service -> (branch: String?, serviceName: String, request: URLRequest) in
-            let url = URL(string: "https://raw.githubusercontent.com/\(swaggerFile.organisation)/\(service.key)/\(service.value.branch ?? "master")/\(service.value.swaggerFilePath ?? swaggerFile.path)")!
+            let url = URL(string: "https://raw.githubusercontent.com/\(swaggerFile.organisation)/\(service.key)/\(service.value.branch ?? "master")/\(service.value.path ?? swaggerFile.path)")!
             if verbose {
                 print("Downloading Swagger at: \(url.absoluteString)", to: &stdout)
             }


### PR DESCRIPTION
I was a bit too fast last week, I think it should be the same field name as in the swagger file so it is clear to be an overwrite.