### PR TITLE
:bug: Parsing an enum response fails on iOS 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             ]),
         .target(
             name: "SwaggerSwiftCore", dependencies: [
-                .product(name: "SwaggerSwiftML", package: "SwaggerSwiftML"),
+                .product(name: "SwaggerSwiftML", package: "SwaggerSwiftML")
             ]),
         .testTarget(
             name: "SwaggerSwiftCoreTests",

--- a/Sources/SwaggerSwiftCore/Functions/getFunctionParameters.swift
+++ b/Sources/SwaggerSwiftCore/Functions/getFunctionParameters.swift
@@ -210,7 +210,13 @@ private func createResultEnumType(types: [(HTTPStatusCodes, TypeType)], failure:
             }
         }
 
-        let enumeration = ModelDefinition.enumeration(Enumeration(serviceName: swagger.serviceName, description: "Result enum", typeName: typeName, values: fields, isCodable: false))
+        let enumeration = ModelDefinition.enumeration(
+            Enumeration(serviceName: swagger.serviceName,
+                        description: nil,
+                        typeName: typeName,
+                        values: fields,
+                        isCodable: false)
+        )
 
         return (typeName, [enumeration])
     } else if filteredTypes.count == 1 {

--- a/Sources/SwaggerSwiftCore/Models/Enumeration.swift
+++ b/Sources/SwaggerSwiftCore/Models/Enumeration.swift
@@ -133,7 +133,7 @@ extension Enumeration: Swiftable {
         }
 
         var fileSections = ""
-        fileSections += packagesToImport.map{"import \($0)"}.joined(separator: "\n")
+        fileSections += packagesToImport.map {"import \($0)"}.joined(separator: "\n")
         if let serviceName = serviceName {
             fileSections += "\n\nextension \(serviceName) {\n"
         }
@@ -150,26 +150,6 @@ extension Enumeration: Swiftable {
             fileSections += "}"
         }
 
-        return fileSections
-    }
-}
-
-extension String {
-    func indentLines(_ count: Int) -> String {
-        self.split(separator: "\n", omittingEmptySubsequences: false)
-            .map {
-                if $0.trimmingCharacters(in: .whitespaces).count > 0 {
-                    return String(repeating: defaultSpacing, count: count) + $0
-                } else {
-                    return ""
-                }
-            }
-            .joined(separator: "\n")
-    }
-}
-
-extension String {
-    var isNumber: Bool {
-        return !isEmpty && rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil
+        return fileSections + "\n"
     }
 }

--- a/Sources/SwaggerSwiftCore/Models/NetworkRequestFunction.swift
+++ b/Sources/SwaggerSwiftCore/Models/NetworkRequestFunction.swift
@@ -185,7 +185,7 @@ if let \(($0.headerModelName)) = headers.\($0.headerModelName) {
             }.joined(separator: "\n")
 
             bodyInjection += """
-                \n
+
                 if let endBoundaryData = "--\\(boundary)--".data(using: .utf8) {
                     requestData.append(endBoundaryData)
                 }

--- a/Sources/SwaggerSwiftCore/SwaggerFileParser/Models/SwaggerFile.swift
+++ b/Sources/SwaggerSwiftCore/SwaggerFileParser/Models/SwaggerFile.swift
@@ -1,5 +1,5 @@
 struct SwaggerFile: Decodable {
-    
+
     let path: String
     let organisation: String
     let services: [String: Service]
@@ -12,7 +12,7 @@ struct SwaggerFile: Decodable {
         case globalHeaders
     }
 
-    init(path: String, organisation: String, services: [String : Service], globalHeaders: [String]?) {
+    init(path: String, organisation: String, services: [String: Service], globalHeaders: [String]?) {
         self.path = path
         self.organisation = organisation
         self.services = services

--- a/Sources/SwaggerSwiftCore/Swift Package/create_swift_package.swift
+++ b/Sources/SwaggerSwiftCore/Swift Package/create_swift_package.swift
@@ -19,13 +19,13 @@ class SwiftPackageBuilder {
     private let projectName: String
     private let platforms: String // Find better datastructure
     private var products: [Product]
-    
+
     init(projectName: String, platforms: String, products: [Product] = []) {
         self.projectName = projectName
         self.platforms = platforms
         self.products = products
     }
-    
+
     func buildPackageFile() -> String {
         let products = self.products.sorted(by: { $0.name < $1.name })
 
@@ -60,9 +60,9 @@ class SwiftPackageBuilder {
     """
     // swift-tools-version:5.5
     // The swift-tools-version declares the minimum version of Swift required to build this package.
-    
+
     import PackageDescription
-    
+
     let package = Package(
         name: "PROJECT_NAME",
         platforms: [.iOS(.v12)],
@@ -81,7 +81,7 @@ class SwiftPackageBuilder {
             .replacingOccurrences(of: "PRODUCTS", with: productsLine)
             .replacingOccurrences(of: "TARGETS", with: targetsLine)
     }
-    
+
 }
 
 func createSwiftProject(at path: String, named name: String, sharedTargetName: String, targets: [String] = [], fileManager: FileManager = FileManager.default) throws {
@@ -100,4 +100,3 @@ func createSwiftProject(at path: String, named name: String, sharedTargetName: S
         .replacingOccurrences(of: "PROJECT_NAME", with: name)
         .write(toFile: expandPath + "/Package.swift", atomically: true, encoding: .utf8)
 }
-

--- a/Sources/SwaggerSwiftCore/Utilities/String+IndentLines.swift
+++ b/Sources/SwaggerSwiftCore/Utilities/String+IndentLines.swift
@@ -1,0 +1,13 @@
+extension String {
+    func indentLines(_ count: Int) -> String {
+        self.split(separator: "\n", omittingEmptySubsequences: false)
+            .map {
+                if $0.trimmingCharacters(in: .whitespaces).count > 0 {
+                    return String(repeating: defaultSpacing, count: count) + $0
+                } else {
+                    return ""
+                }
+            }
+            .joined(separator: "\n")
+    }
+}

--- a/Sources/SwaggerSwiftCore/Utilities/String+IsNumber.swift
+++ b/Sources/SwaggerSwiftCore/Utilities/String+IsNumber.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension String {
+    var isNumber: Bool {
+        return !isEmpty && rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil
+    }
+}

--- a/Sources/SwaggerSwiftCore/parseRequest.swift
+++ b/Sources/SwaggerSwiftCore/parseRequest.swift
@@ -1,9 +1,19 @@
 import SwaggerSwiftML
 
-func parse(request requestNode: Node<Response>, httpMethod: HTTPMethod, servicePath: String, statusCode: Int, swagger: Swagger) -> (TypeType, [ModelDefinition]) {
-    let prefix = "\(servicePath.replacingOccurrences(of: "{", with: "").replacingOccurrences(of: "}", with: "").components(separatedBy: "/").map { $0.components(separatedBy: "-") }.flatMap { $0 }.map { $0.uppercasingFirst }.joined().capitalizingFirstLetter())\(statusCode)"
+func parse(request requestNode: Node<SwaggerSwiftML.Response>, httpMethod: HTTPMethod, servicePath: String, statusCode: Int, swagger: Swagger) -> (TypeType, [ModelDefinition]) {
+    let requestName = servicePath
+        .replacingOccurrences(of: "{", with: "")
+        .replacingOccurrences(of: "}", with: "")
+        .components(separatedBy: "/")
+        .map { $0.components(separatedBy: "-") }
+        .flatMap { $0 }
+        .map { $0.uppercasingFirst }
+        .joined()
+        .capitalizingFirstLetter()
 
-    let request: Response
+    let prefix = "\(requestName)\(statusCode)"
+
+    let request: SwaggerSwiftML.Response
     switch requestNode {
     case .reference(let ref):
 		let pathParts = ref.split(separator: "/").map { String($0) }
@@ -18,7 +28,7 @@ func parse(request requestNode: Node<Response>, httpMethod: HTTPMethod, serviceP
 				fatalError("\(swagger.serviceName): Failed to find referenced object: \(ref)")
 			}
 
-			request = Response(schema: schema)
+            request = SwaggerSwiftML.Response(schema: schema)
 		case "responses":
 			guard let req = swagger.responses?[typeName] else {
 				fatalError("\(swagger.serviceName): Failed to find referenced object: \(ref)")

--- a/Sources/SwaggerSwiftCore/start.swift
+++ b/Sources/SwaggerSwiftCore/start.swift
@@ -246,7 +246,7 @@ public func start(swaggerFilePath: String, token: String, destinationPath: Strin
     try! createSwiftProject(at: destinationPath, named: projectName, sharedTargetName: sharedTargetName, targets: swaggers.map(\.serviceName))
 
     let sharedDirectory = [destinationPath, "Sources", sharedTargetName].joined(separator: "/")
-    
+
     try FileManager.default.createDirectory(atPath: sharedDirectory,
                                     withIntermediateDirectories: true,
                                     attributes: nil)

--- a/Tests/SwaggerSwiftCoreTests/SwaggerSwiftCoreTests.swift
+++ b/Tests/SwaggerSwiftCoreTests/SwaggerSwiftCoreTests.swift
@@ -2,11 +2,11 @@ import XCTest
 @testable import SwaggerSwiftCore
 
 final class SwaggerSwiftTests: XCTestCase {
-    
+
     let swaggerFile = SwaggerFile(path: "", organisation: "", services: [:], globalHeaders: nil)
-    
+
     func testOptionalURLDecodeFormat() {
-        
+
         let model = Model(description: nil,
                           typeName: "Test",
                           fields: [.init(description: nil, type: .object(typeName: "URL"), name: "url", required: false)],
@@ -38,9 +38,9 @@ public struct Test: Codable {
 }
 """)
     }
-    
+
     func testURLDecodeFormat() {
-        
+
         let model = Model(description: nil,
                           typeName: "Test",
                           fields: [.init(description: nil, type: .object(typeName: "URL"), name: "url", required: true)],


### PR DESCRIPTION
If you had a response with a type that was just an enum the parser would fail on iOS 12. The reason is that JSONDecoder doesn't support JSON fragments which an enum would be (it is sent as something like this: `"\"ENUM_VALUE\”\n"`)

This fix changes it to be a custom string parser, which then converts it into the right enum value.