### PR TITLE
:bug: Fix enum parsing on iOS 12 … again

### DIFF
--- a/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
@@ -124,6 +124,8 @@ struct APIFactory {
                 break
             case .object:
                 break
+            case .enumeration:
+                break
             }
         }
 

--- a/Sources/SwaggerSwiftCore/API Request Factory/APIResponseTypeFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Request Factory/APIResponseTypeFactory.swift
@@ -57,6 +57,10 @@ public struct APIResponseTypeFactory {
                     return APIRequestResponseType.object(response.statusCode,
                                                          response.statusCode.isSuccess ? successResponses.count > 1 : errorResponses.count > 1,
                                                          typeName: typeName)
+                case .enumeration(let typeName):
+                    return .enumeration(response.statusCode,
+                                        response.statusCode.isSuccess ? successResponses.count > 1 : errorResponses.count > 1,
+                                        typeName: typeName)
                 case .void:
                     return APIRequestResponseType.void(response.statusCode,
                                                        response.statusCode.isSuccess ? successResponses.count > 1 : errorResponses.count > 1)

--- a/Sources/SwaggerSwiftCore/API Request Factory/Models/APIRequest+Swiftable.swift
+++ b/Sources/SwaggerSwiftCore/API Request Factory/Models/APIRequest+Swiftable.swift
@@ -81,7 +81,8 @@ if let \(($0.swiftyName)) = headers.\($0.swiftyName) {
                     fatalError("not implemented")
                 case .array:
                     fatalError("not implemented")
-                case .object(typeName: let typeName):
+                case .enumeration(let typeName): fallthrough
+                case .object(let typeName):
                     if typeName == "FormData" {
                         return "requestData.append(\($0.name).toRequestData(named: \"\($0.name)\", using: boundary))"
                     } else if $0.isEnum {

--- a/Sources/SwaggerSwiftCore/Extensions/Schema.swift
+++ b/Sources/SwaggerSwiftCore/Extensions/Schema.swift
@@ -23,7 +23,7 @@ extension Schema {
         switch self.type {
         case .string(_, let enumValues, _, _, _):
             if let enumValues = enumValues, enumValues.count > 0 {
-                return TypeType.object(typeName: name)
+                return TypeType.enumeration(typeName: name)
             } else {
                 return TypeType.string
             }

--- a/Sources/SwaggerSwiftCore/Model Type Resolver/ModelTypeResolver.swift
+++ b/Sources/SwaggerSwiftCore/Model Type Resolver/ModelTypeResolver.swift
@@ -35,7 +35,7 @@ public struct ModelTypeResolver {
                                                                     values: enumValues,
                                                                     isCodable: true))
 
-                return .init(.object(typeName: enumTypename), [model])
+                return ResolvedModel(.enumeration(typeName: enumTypename), [model])
             }
 
             if let format = format {

--- a/Sources/SwaggerSwiftCore/Model Type Resolver/ObjectModelFactory.swift
+++ b/Sources/SwaggerSwiftCore/Model Type Resolver/ObjectModelFactory.swift
@@ -208,10 +208,12 @@ public class ObjectModelFactory {
                                                              typeNamePrefix: typeName,
                                                              namespace: namespace,
                                                              swagger: swagger)
+
                 let field = ModelField(description: schema.description,
                                        type: resolvedType.propertyType,
                                        name: name,
                                        isRequired: isRequired)
+
                 return (field, resolvedType.inlineModelDefinitions)
             }
         case .node(let schema):

--- a/Sources/SwaggerSwiftCore/Models/TypeType.swift
+++ b/Sources/SwaggerSwiftCore/Models/TypeType.swift
@@ -11,6 +11,7 @@ indirect enum TypeType {
     case int64
     case array(typeName: TypeType)
     case object(typeName: String)
+    case enumeration(typeName: String)
     case date
     case void
 
@@ -23,9 +24,9 @@ indirect enum TypeType {
                 return "Int"
             case .double:
                 return "Double"
-            case .array(typeName: let typeName):
+            case .array(let typeName):
                 return "[\(typeName.toString(required: true))]"
-            case .object(typeName: let typeName):
+            case .object(let typeName):
                 return typeName
             case .void:
                 return "Void"
@@ -37,6 +38,8 @@ indirect enum TypeType {
                 return "Int64"
             case .date:
                 return "Date"
+            case .enumeration(let typeName):
+                return typeName
             }
         }(self) + (required ? "" : "?")
     }


### PR DESCRIPTION
Probably during a refactor the iOS 12 code was invalidated. Now `enum` has been lifted to a top level `TypeType`. It behaves almost like a normal `object` type but when it is parsed it will use a special function that avoids the JSON leaf issue on iOS 12.