### PR TITLE
:bug: Fix default naming

### DIFF
--- a/Sources/SwaggerSwift/MyMain.swift
+++ b/Sources/SwaggerSwift/MyMain.swift
@@ -5,7 +5,7 @@ import SwaggerSwiftCore
 struct SwaggerSwiftParser: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "Path to SwaggerFile")
     var swaggerFilePath: String = "./SwaggerFile"
-    
+
     @Option(name: .shortAndLong, help: "Set logging to be verbose")
     var verbose: Bool = false
 

--- a/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
@@ -4,7 +4,7 @@ import SwaggerSwiftML
 struct APIFactory {
     let apiRequestFactory: APIRequestFactory
     let modelTypeResolver: ModelTypeResolver
-    
+
     func generate(for swagger: Swagger, withSwaggerFile swaggerFile: SwaggerFile) throws -> (APIDefinition, [ModelDefinition]) {
         let (apiFunctions, inlineModelDefinitions) = try getApiList(fromSwagger: swagger, swaggerFile: swaggerFile)
         let modelDefinitions = getModelDefinitions(fromSwagger: swagger)

--- a/Sources/SwaggerSwiftCore/API Request Factory/RequestParameterFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Request Factory/RequestParameterFactory.swift
@@ -231,8 +231,8 @@ public struct RequestParameterFactory {
     }
 
     private func resolveBodyParameters(parameters: [SwaggerSwiftML.Parameter], typePrefix: String, namespace: String, swagger: Swagger) -> (FunctionParameter, [ModelDefinition])? {
-        var schemaNode: Node<Schema>? = nil
-        var parameter: Parameter? = nil
+        var schemaNode: Node<Schema>?
+        var parameter: Parameter?
         for param in parameters {
             if case let ParameterLocation.body(schema) = param.location {
                 schemaNode = schema.value

--- a/Sources/SwaggerSwiftCore/Functions/parseRequest.swift
+++ b/Sources/SwaggerSwiftCore/Functions/parseRequest.swift
@@ -65,4 +65,3 @@ func parse(request requestNode: Node<SwaggerSwiftML.Response>, httpMethod: HTTPM
         return (.void, [])
     }
 }
-

--- a/Sources/SwaggerSwiftCore/Generator/Generator.swift
+++ b/Sources/SwaggerSwiftCore/Generator/Generator.swift
@@ -168,7 +168,7 @@ public struct Generator {
             case noData
         }
         return try await withCheckedThrowingContinuation { continuation in
-            URLSession.shared.dataTask(with: request) { data, response, error in
+            URLSession.shared.dataTask(with: request) { data, response, _ in
                 guard let data = data, let response = response else {
                     continuation.resume(throwing: FetchError.noData)
                     return

--- a/Sources/SwaggerSwiftCore/Generator/Models/GlobalHeadersModel.swift
+++ b/Sources/SwaggerSwiftCore/Generator/Models/GlobalHeadersModel.swift
@@ -29,16 +29,20 @@ struct GlobalHeadersModel {
 
         model += "\n\n"
 
-        model += "internal extension \(typeName) {\n"
+        model += "\(accessControl.rawValue) extension \(typeName) {\n"
 
-        model += addToRequestFunction(accessControl: accessControl.rawValue).indentLines(1)
+        model += addToRequestFunction().indentLines(1)
+
+        model += "\n\n"
+
+        model += asDictionaryFunction().indentLines(1)
 
         model += "\n}\n"
 
         return model
     }
 
-    func addToRequestFunction(accessControl: String) -> String {
+    func addToRequestFunction() -> String {
         let fields = headerFields.map {
             APIRequestHeaderField(
                 headerName: $0,
@@ -59,6 +63,38 @@ if let \($0.swiftyName) = \($0.swiftyName) {
 """ }
             .joined(separator: "\n\n")
             .indentLines(1)
+
+        function += "\n"
+
+        function += "}"
+
+        return function
+    }
+
+    func asDictionaryFunction() -> String {
+        let fields = headerFields.map {
+            APIRequestHeaderField(
+                headerName: $0,
+                isRequired: false
+            )
+        }
+
+        var function = ""
+
+        function += "var asDictionary: [String: String] {\n"
+        function += "var headers = [String: String]()\n\n".indentLines(1)
+
+        function += fields
+            .sorted(by: { $0.swiftyName < $1.swiftyName })
+            .map { """
+if let \($0.swiftyName) = \($0.swiftyName) {
+    headers[\"\($0.fullHeaderName)\"] = \($0.swiftyName)
+}
+""" }
+            .joined(separator: "\n\n")
+            .indentLines(1)
+
+        function += "\n\nreturn headers".indentLines(1)
 
         function += "\n"
 

--- a/Sources/SwaggerSwiftCore/Generator/Models/SwiftPackageBuilder.swift
+++ b/Sources/SwaggerSwiftCore/Generator/Models/SwiftPackageBuilder.swift
@@ -70,7 +70,7 @@ class SwiftPackageBuilder {
 
     let package = Package(
         name: "PROJECT_NAME",
-        platforms: [.iOS(.v12), .macOS(.v12)],
+        platforms: [.iOS(.v14), .macOS(.v12)],
         products: [
     PRODUCTS
         ],

--- a/Sources/SwaggerSwiftCore/Model Type Resolver/ObjectModelFactory.swift
+++ b/Sources/SwaggerSwiftCore/Model Type Resolver/ObjectModelFactory.swift
@@ -182,7 +182,7 @@ public class ObjectModelFactory {
                 allOfParts.append(allOfPart)
             }
         }
-        
+
         return allOfParts
     }
 

--- a/Sources/SwaggerSwiftCore/Models/ModelDefinition.swift
+++ b/Sources/SwaggerSwiftCore/Models/ModelDefinition.swift
@@ -22,7 +22,6 @@ extension ModelDefinition {
         }
     }
 
-
     func toSwift(serviceName: String?, embedded: Bool, accessControl: APIAccessControl, packagesToImport: [String]) -> String {
         switch self {
         case .enumeration(let enumeration):

--- a/Sources/SwaggerSwiftCore/Models/ModelField.swift
+++ b/Sources/SwaggerSwiftCore/Models/ModelField.swift
@@ -49,7 +49,7 @@ extension Sequence where Element == ModelField {
             let fieldType = "\(field.type.toString(required: field.isRequired || field.defaultValue != nil))"
 
             var declaration: String
-            if field.argumentLabel.variableNameFormatted != field.safeParameterName.value.variableNameFormatted {
+            if field.argumentLabel.variableNameFormatted != field.safeParameterName.value.variableNameFormatted.trimmingCharacters(in: CharacterSet(charactersIn: "`")) {
                 // MyFieldName myFieldName: FieldType
                 declaration = "\(field.argumentLabel.variableNameFormatted) \(field.safeParameterName.value.variableNameFormatted): \(fieldType)"
             } else {

--- a/Sources/SwaggerSwiftCore/Models/SwiftKeyword.swift
+++ b/Sources/SwaggerSwiftCore/Models/SwiftKeyword.swift
@@ -23,17 +23,17 @@ enum SwiftKeyword: String {
         case .kSelf:
             return "this"
         case .kPrivate:
-            return "`private`"
+            return "isPrivate"
         case .kPublic:
-            return "`public`"
+            return "isPublic"
         case .kThrow:
             return "`throw`"
         case .kThrows:
             return "`throws`"
         case .kOverride:
-            return "`override`"
+            return "isOverride"
         case .kDefault:
-            return "`default`"
+            return "isDefault"
         case .kDefer:
             return "`defer`"
         }

--- a/Tests/SwaggerSwiftCoreTests/ResolverTests/StringResolverTests.swift
+++ b/Tests/SwaggerSwiftCoreTests/ResolverTests/StringResolverTests.swift
@@ -90,7 +90,6 @@ class StringResolverTests: XCTestCase {
         }
     }
 
-
     func testLongFormatResolvesToObjectString() {
         let type = StringResolver.resolve(format: .long,
                                           enumValues: nil,


### PR DESCRIPTION
Fix a case where an init parameter called `default` would become: `default ‘default’` and not just `default`. I have also changed it so that default would be called `isDefault` instead.