### PR TITLE
:bug: GlobalHeaderExtensions in modules

### DIFF
--- a/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
@@ -206,7 +206,7 @@ struct APIFactory {
         if hasGlobalHeaders {
             fields.append(APIDefinitionField(name: "headerProvider",
                                              description: "a block provider for the set of globally defined headers",
-                                             typeName: "() -> GlobalHeaders",
+                                             typeName: "() -> any GlobalHeaders",
                                              isRequired: true,
                                              typeIsAutoclosure: false,
                                              typeIsBlock: true,
@@ -215,7 +215,7 @@ struct APIFactory {
 
         fields.append(APIDefinitionField(name: "interceptor",
                                          description: "use this if you need to intercept overall requests",
-                                         typeName: "NetworkInterceptor",
+                                         typeName: "(any NetworkInterceptor)",
                                          isRequired: false,
                                          typeIsAutoclosure: false,
                                          typeIsBlock: false,

--- a/Sources/SwaggerSwiftCore/Static Files/APIInitializeFile.swift
+++ b/Sources/SwaggerSwiftCore/Static Files/APIInitializeFile.swift
@@ -5,8 +5,8 @@ import Foundation
 public protocol APIInitialize {
     init(urlSession: @escaping () -> URLSession,
          baseUrlProvider: @escaping () -> URL,
-         headerProvider: @escaping () -> GlobalHeaders,
-         interceptor: NetworkInterceptor?
+         headerProvider: @escaping () -> any GlobalHeaders,
+         interceptor: (any NetworkInterceptor)?
     )
 }
 


### PR DESCRIPTION
Previously one was created per API. This will fail in frameworks with multiple APIs are they will suddenly have multiple copies.