### PR TITLE
:bricks: APIs are now unchecked sendable

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set Xcode
-      run: xcversion select 14.0
+      run: xcversion select 14.2
 
     - name: Run tests
       run: swift test -v --parallel --xunit-output test.xml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,20 +6,20 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set Xcode
-      run: xcversion select 14.0
+      run: xcversion select 14.2
 
     - name: Build
       run: swift build -v
 
   test:
-   runs-on: macos-12
+   runs-on: macos-latest
    steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set Xcode
       run: xcversion select 14.0

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     -
      name: Set up QEMU

--- a/Sources/SwaggerSwiftCore/API Factory/Models/APIDefinition.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/Models/APIDefinition.swift
@@ -44,7 +44,7 @@ struct APIDefinition {
             .trimmingCharacters(in: CharacterSet.newlines)
 
         serviceDefinition += """
-\(accessControl) struct \(serviceName): APIInitialize {
+\(accessControl) struct \(serviceName): @unchecked Sendable, APIInitialize {
 \(properties)
 
 \(initMethod)


### PR DESCRIPTION
This is in no way the right solution. SwaggerSwift will now add unchecked Sendable to all APIs so that they can be used in async contexts. The reason they aren't just "Sendable" is that the API queries for the app state at every request. Since this can result in data races it can't be Sendable in its current state. This is made in this way to make it simpler for us as developers, but also gets us into the territory of:
1. user making request
2. request starts
3. user logs out (or is thrown out)
4. request sent with previous users' data

It should probably be fixed in another manner, but e.g. forcing us to send in the users data, but that is a bigger refactor, and probably not that big of a problem atm.