### PR TITLE
:lipstick: Only one JSONDecoder

### DIFF
--- a/Sources/SwaggerSwiftCore/API Request Factory/Models/APIRequest+Swiftable.swift
+++ b/Sources/SwaggerSwiftCore/API Request Factory/Models/APIRequest+Swiftable.swift
@@ -172,6 +172,9 @@ private func _\(functionName)(\(functionArguments)) async -> \(functionReturnTyp
         return .failure(.requestFailed(error: error))
     }
 
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .custom(dateDecodingStrategy)
+
     switch httpResponse.statusCode {
 \(responseTypes.indentLines(1))
     default:

--- a/Sources/SwaggerSwiftCore/API Request Factory/Models/APIRequestResponseType.swift
+++ b/Sources/SwaggerSwiftCore/API Request Factory/Models/APIRequestResponseType.swift
@@ -70,8 +70,6 @@ case \(statusCode.rawValue):
                 return """
 case \(statusCode.rawValue):
     do {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .custom(dateDecodingStrategy)
         let result = try decoder.decode(\(responseType.modelNamed).self, from: data)
 
         return .\(swiftResult)(\(resultType("result", resultIsEnum)))
@@ -180,8 +178,6 @@ case \(statusCode.rawValue):
             return """
 case \(statusCode.rawValue):
     do {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .custom(dateDecodingStrategy)
         let result = try decoder.decode([\(innerType)].self, from: data)
 
         return .\(swiftResult)(\(resultType("result", resultIsEnum)))


### PR DESCRIPTION
In the olden times the code would create a decoder per response type. Now we only create one.