### PR TITLE
:sparkles: Add header override

### DIFF
--- a/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
@@ -201,7 +201,7 @@ struct APIFactory {
                                defaultValue: nil)
         ]
 
-        let hasGlobalHeaders = (swaggerFile.globalHeaders ?? []).count > 0
+        let hasGlobalHeaders = swaggerFile.globalHeaders.count > 0
 
         if hasGlobalHeaders {
             fields.append(APIDefinitionField(name: "headerProvider",

--- a/Sources/SwaggerSwiftCore/Extensions/Parameter.swift
+++ b/Sources/SwaggerSwiftCore/Extensions/Parameter.swift
@@ -9,6 +9,13 @@ enum ParamLocation {
     case body
 }
 
+struct HeaderParameter {
+    let type: ParameterType
+    let name: String
+    let required: Bool
+    let description: String?
+}
+
 extension Sequence where Element == SwaggerSwiftML.Parameter {
     /// Convenience function that searches a set of SwaggerSwiftML.Parameter's to find those that are used in a specific location, based on `ParamLocation`
     /// - Parameter type: the type of api parameter that is needed

--- a/Sources/SwaggerSwiftCore/Generator/Generator.swift
+++ b/Sources/SwaggerSwiftCore/Generator/Generator.swift
@@ -97,7 +97,7 @@ public struct Generator {
 
         log("Creating Swift Project at \(destination)")
 
-        let globalHeadersModel = GlobalHeadersModel(headerFields: swaggerFile.globalHeaders ?? [])
+        let globalHeadersModel = GlobalHeadersModel(headerFields: swaggerFile.globalHeaders)
         let commonLibraryName = "\(swaggerFile.projectName)Shared"
 
         if swaggerFile.createSwiftPackage {
@@ -226,7 +226,17 @@ public struct Generator {
         }
     }
 
-    private func write(apiDefinition: APIDefinition, modelDefinitions: [ModelDefinition], swaggerFile: SwaggerFile, rootDirectory: String, commonLibraryName: String?, accessControl: APIAccessControl, globalHeadersModel: GlobalHeadersModel, fileManager: FileManager, dummyMode: Bool) throws {
+    private func write(
+        apiDefinition: APIDefinition,
+        modelDefinitions: [ModelDefinition],
+        swaggerFile: SwaggerFile,
+        rootDirectory: String,
+        commonLibraryName: String?,
+        accessControl: APIAccessControl,
+        globalHeadersModel: GlobalHeadersModel,
+        fileManager: FileManager,
+        dummyMode: Bool
+    ) throws {
         log("Parsing contents of Swagger: \(apiDefinition.serviceName)")
 
         let apiDirectory = rootDirectory + "/" + apiDefinition.serviceName
@@ -300,8 +310,8 @@ public struct Generator {
             try globalHeadersDefinitions.write(toFile: globalHeaderExtensionsPath)
         }
 
-        if let globalHeaderFields = swaggerFile.globalHeaders {
-            let globalHeadersModel = GlobalHeadersModel(headerFields: globalHeaderFields)
+        if swaggerFile.globalHeaders.count > 0 {
+            let globalHeadersModel = GlobalHeadersModel(headerFields: swaggerFile.globalHeaders)
             let globalHeadersFileContents = globalHeadersModel.toSwift(swaggerFile: swaggerFile, accessControl: accessControl)
             try globalHeadersFileContents.write(toFile: "\(targetPath)/GlobalHeaders.swift")
         }

--- a/Sources/SwaggerSwiftCore/Generator/Models/GlobalHeadersModel.swift
+++ b/Sources/SwaggerSwiftCore/Generator/Models/GlobalHeadersModel.swift
@@ -54,7 +54,7 @@ struct GlobalHeadersModel {
         return model
     }
 
-    func addToRequestFunction() -> String {
+    private func addToRequestFunction() -> String {
         let fields = headerFields.map {
             APIRequestHeaderField(
                 headerName: $0,
@@ -83,7 +83,7 @@ if let \($0.swiftyName) = \($0.swiftyName) {
         return function
     }
 
-    func asDictionaryFunction() -> String {
+    private func asDictionaryFunction() -> String {
         let fields = headerFields.map {
             APIRequestHeaderField(
                 headerName: $0,

--- a/Sources/SwaggerSwiftCore/SwaggerFile Parser/Models/SwaggerFile.swift
+++ b/Sources/SwaggerSwiftCore/SwaggerFile Parser/Models/SwaggerFile.swift
@@ -8,7 +8,7 @@ struct SwaggerFile: Decodable {
     let path: String
     let organisation: String
     let services: [String: Service]
-    let globalHeaders: [String]?
+    let globalHeaders: [String]
     let createSwiftPackage: Bool
     /// What is the name of the directory the files will be placed in? This is also the name as the project in the Swift Package (if created)
     let projectName: String
@@ -27,7 +27,16 @@ struct SwaggerFile: Decodable {
         case destination
     }
 
-    init(path: String, organisation: String, services: [String: Service], globalHeaders: [String]?, createSwiftPackage: Bool = true, accessControl: APIAccessControl = .public, destination: String = "./", projectName: String = "Services") {
+    init(
+        path: String,
+        organisation: String,
+        services: [String: Service],
+        globalHeaders: [String] = [],
+        createSwiftPackage: Bool = true,
+        accessControl: APIAccessControl = .public,
+        destination: String = "./",
+        projectName: String = "Services"
+    ) {
         self.path = path
         self.organisation = organisation
         self.services = services
@@ -43,7 +52,7 @@ struct SwaggerFile: Decodable {
         self.path = try container.decode(String.self, forKey: .path)
         self.organisation = try container.decode(String.self, forKey: .organisation)
         self.services = try container.decode([String: Service].self, forKey: .services)
-        self.globalHeaders = try container.decodeIfPresent([String].self, forKey: .globalHeaders)
+        self.globalHeaders = (try container.decodeIfPresent([String].self, forKey: .globalHeaders)) ?? []
         self.accessControl = try container.decodeIfPresent(APIAccessControl.self, forKey: .accessControl) ?? .public
         self.createSwiftPackage = try container.decodeIfPresent(Bool.self, forKey: .createSwiftPackage) ?? true
         self.projectName = try container.decodeIfPresent(String.self, forKey: .projectName) ?? "Services"


### PR DESCRIPTION
Currently all headers defined in Global Headers will remove the headers from each request. This is the intended behaviour in most cases. However in some cases, it might be beneficial to override the global headers. This PR adds `headers` to all requests, but making them optional.