### PR TITLE
:sparkles: Supporting new concurrency model

### DIFF
--- a/Sources/SwaggerSwiftCore/API Request Factory/Models/APIRequest+Swiftable.swift
+++ b/Sources/SwaggerSwiftCore/API Request Factory/Models/APIRequest+Swiftable.swift
@@ -238,7 +238,7 @@ private func _\(functionName)(\(functionArguments)) async -> \(functionReturnTyp
         body += "\n"
 
         body += """
-        \(accessControl) func \(functionName)(\(functionArguments)\(functionArguments.isEmpty ? "" : ", ")completion: @escaping (\(functionReturnType)) -> Void = { _ in }) {
+        \(accessControl) func \(functionName)(\(functionArguments)\(functionArguments.isEmpty ? "" : ", ")completion: @Sendable @escaping (\(functionReturnType)) -> Void = { _ in }) {
             _Concurrency.Task {
                 let result = await _\(functionName)(\(parameters.map { "\($0.name.variableNameFormatted): \($0.name.variableNameFormatted)" }.joined(separator: ", ")))
                 completion(result)

--- a/Sources/SwaggerSwiftCore/Static Files/ServiceErrorFile.swift
+++ b/Sources/SwaggerSwiftCore/Static Files/ServiceErrorFile.swift
@@ -1,5 +1,5 @@
 let serviceError = """
-<ACCESSCONTROL> enum ServiceError<ErrorType>: Error {
+<ACCESSCONTROL> enum ServiceError<ErrorType: Sendable>: Error {
     // The request failed, e.g. timeout
     case requestFailed(error: Error)
     // The backend returned an error, e.g. a 500 Internal Server Error, 403 Unauthorized


### PR DESCRIPTION
Adding Sendable to remove Swift concurrency warnings in Swift 6