### PR TITLE
:sparkles: Support enum in query parameters

### DIFF
--- a/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
@@ -45,10 +45,12 @@ struct APIFactory {
         var networkRequestFunctions = [APIRequest]()
         var inlineModelDefinitions = [ModelDefinition]()
         for swaggerPath in swagger.paths {
-            let (pathNetworkRequestFunctions, pathCurrentInlineDefinitions) = try apisAndModels(fromPath: swaggerPath.value,
-                                                                                                servicePath: swaggerPath.key,
-                                                                                                swagger: swagger,
-                                                                                                swaggerFile: swaggerFile)
+            let (pathNetworkRequestFunctions, pathCurrentInlineDefinitions) = try apisAndModels(
+                fromPath: swaggerPath.value,
+                servicePath: swaggerPath.key,
+                swagger: swagger,
+                swaggerFile: swaggerFile
+            )
 
             networkRequestFunctions.append(contentsOf: pathNetworkRequestFunctions)
             inlineModelDefinitions.append(contentsOf: pathCurrentInlineDefinitions)
@@ -130,6 +132,7 @@ struct APIFactory {
                 break
             }
         }
+        
         return allDefinitions
     }
 

--- a/Sources/SwaggerSwiftCore/API Request Factory/RequestParameterFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Request Factory/RequestParameterFactory.swift
@@ -19,7 +19,7 @@ public struct RequestParameterFactory {
     ///   - swaggerFile: the swagger file
     /// - Returns: the list of all parameters to the API request
     func make(forOperation operation: SwaggerSwiftML.Operation, functionName: String, responseTypes: [ResponseTypeMap], pathParameters: [Parameter], swagger: Swagger, swaggerFile: SwaggerFile) throws -> ([FunctionParameter], [ModelDefinition], ReturnType) {
-        let parameters = (operation.parameters ?? []).map {
+        let parameters: [Parameter] = (operation.parameters ?? []).map {
             swagger.findParameter(node: $0)
         } + pathParameters
 
@@ -42,12 +42,20 @@ public struct RequestParameterFactory {
         }
 
         // Path
-        let (pathParameters, pathModels) = try resolvePathParameters(parameters: parameters, typePrefix: typeName, swagger: swagger)
+        let (pathParameters, pathModels) = try resolvePathParameters(
+            parameters: parameters,
+            typePrefix: typeName,
+            swagger: swagger
+        )
         resolvedParameters.append(contentsOf: pathParameters)
         resolvedModelDefinitions.append(contentsOf: pathModels)
 
         // Query
-        let (queryParameters, queryModels) = try resolveQueryParameters(parameters: parameters, typePrefix: typeName, swagger: swagger)
+        let (queryParameters, queryModels) = try resolveQueryParameters(
+            parameters: parameters,
+            typePrefix: typeName,
+            swagger: swagger
+        )
         resolvedParameters.append(contentsOf: queryParameters)
         resolvedModelDefinitions.append(contentsOf: queryModels)
 
@@ -65,9 +73,20 @@ public struct RequestParameterFactory {
         resolvedModelDefinitions.append(contentsOf: formDataModels)
 
         // Completion
-        let (successTypeName, successInlineModels) = createResultEnumType(types: responseTypes, failure: false, functionName: functionName, swagger: swagger)
+        let (successTypeName, successInlineModels) = createResultEnumType(
+            types: responseTypes,
+            failure: false,
+            functionName: functionName,
+            swagger: swagger
+        )
         resolvedModelDefinitions.append(contentsOf: successInlineModels)
-        let (failureTypeName, failureInlineModels) = createResultEnumType(types: responseTypes, failure: true, functionName: functionName, swagger: swagger)
+        
+        let (failureTypeName, failureInlineModels) = createResultEnumType(
+            types: responseTypes,
+            failure: true,
+            functionName: functionName,
+            swagger: swagger
+        )
         resolvedModelDefinitions.append(contentsOf: failureInlineModels)
 
         let returnType = ReturnType(
@@ -102,7 +121,8 @@ public struct RequestParameterFactory {
                             description: nil,
                             typeName: typeName,
                             values: fields,
-                            isCodable: false)
+                            isCodable: false, 
+                            collectionFormat: nil)
             )
 
             return (typeName, [enumeration])
@@ -337,7 +357,8 @@ public struct RequestParameterFactory {
                                                                description: parameter.description,
                                                                typeName: typeName,
                                                                values: enumValues,
-                                                               isCodable: true)))
+                                                               isCodable: true,
+                                                               collectionFormat: nil)))
 
                     let param = FunctionParameter(description: parameter.description,
                                                   name: parameter.name,

--- a/Sources/SwaggerSwiftCore/Generator/Generator.swift
+++ b/Sources/SwaggerSwiftCore/Generator/Generator.swift
@@ -59,9 +59,10 @@ public struct Generator {
                         swaggerPath: service.value.path ?? swaggerFile.path
                     )
 
-                    let apiSpec = try await APIFactory(apiRequestFactory: apiRequestFactory,
-                                                       modelTypeResolver: modelTypeResolver)
-                        .generate(for: swagger, withSwaggerFile: swaggerFile)
+                    let apiSpec = try await APIFactory(
+                        apiRequestFactory: apiRequestFactory,
+                        modelTypeResolver: modelTypeResolver
+                    ).generate(for: swagger, withSwaggerFile: swaggerFile)
 
                     return apiSpec
                 }

--- a/Sources/SwaggerSwiftCore/Model Type Resolver/ModelTypeResolver.swift
+++ b/Sources/SwaggerSwiftCore/Model Type Resolver/ModelTypeResolver.swift
@@ -37,7 +37,8 @@ public struct ModelTypeResolver {
                                                                     description: schema.description,
                                                                     typeName: enumTypeName,
                                                                     values: enumValues ?? [],
-                                                                    isCodable: true))
+                                                                    isCodable: true, 
+                                                                    collectionFormat: nil))
                 return ResolvedModel(.enumeration(typeName: enumTypeName), [model])
             }
 
@@ -130,11 +131,17 @@ public struct ModelTypeResolver {
                                                   serviceName: swagger.serviceName)
 
                 if case .enumeration(let enumTypeName) = type {
-                    let model = ModelDefinition.enumeration(Enumeration(serviceName: swagger.serviceName,
-                                                                        description: schema.description,
-                                                                        typeName: enumTypeName,
-                                                                        values: enumValues ?? [],
-                                                                        isCodable: true))
+                    let model = ModelDefinition.enumeration(
+                        Enumeration(
+                            serviceName: swagger.serviceName,
+                            description: schema.description,
+                            typeName: enumTypeName,
+                            values: enumValues ?? [],
+                            isCodable: true,
+                            
+                            collectionFormat: nil
+                        )
+                    )
                     return (.enumeration(typeName: enumTypeName), [model])
                 } else {
                     return (type, [])

--- a/Sources/SwaggerSwiftCore/Models/Enumeration.swift
+++ b/Sources/SwaggerSwiftCore/Models/Enumeration.swift
@@ -8,6 +8,7 @@ struct Enumeration {
     let typeName: String
     let values: [String]
     let isCodable: Bool
+    let collectionFormat: CollectionFormat?
 
     static func toCasename(_ str: String, _ isCodable: Bool) -> String {
         let str = isCodable ? str.camelized : str


### PR DESCRIPTION
If you define a query parameter as being an enum, it wasn't previously supported. It is now.

Can be seen generated here: https://github.com/lunarway/ios-app/pull/9364