### PR TITLE
Use custom coding key and implement codable functions on our own to reduce binary size

### DIFF
--- a/Sources/SwaggerSwiftCore/Generator/Generator.swift
+++ b/Sources/SwaggerSwiftCore/Generator/Generator.swift
@@ -293,6 +293,7 @@ public struct Generator {
         try dateDecodingStrategy.replacingOccurrences(of: "<ACCESSCONTROL>", with: accControl).write(toFile: "\(targetPath)/DateDecodingStrategy.swift")
         try apiInitializeFile.replacingOccurrences(of: "<ACCESSCONTROL>", with: accControl).write(toFile: "\(targetPath)/APIInitialize.swift")
         try apiInitializerFile.replacingOccurrences(of: "<ACCESSCONTROL>", with: accControl).write(toFile: "\(targetPath)/APIInitializer.swift")
+        try stringCodingKey.replacingOccurrences(of: "<ACCESSCONTROL>", with: accControl).write(toFile: "\(targetPath)/StringCodingKey.swift")
 
         if swaggerFile.createSwiftPackage == false {
             let globalHeadersDefinitions = globalHeadersModel.writeExtensions(inCommonPackageNamed: nil)

--- a/Sources/SwaggerSwiftCore/Models/Model.swift
+++ b/Sources/SwaggerSwiftCore/Models/Model.swift
@@ -60,14 +60,11 @@ struct Model {
         let fieldHasDefaultValue = fields.contains(where: { $0.defaultValue != nil })
         let fieldHasOptionalURL = fields.contains(where: { $0.type.toString(required: true) == "URL" && !$0.isRequired })
 
-        if isCodable && (fieldsChangesSwaggerFieldNames || fieldHasDefaultValue || fieldHasOptionalURL) {
+        if isCodable {
             model += "\n\n"
-            model += decodeFunction().indentLines(1)
-        }
-
-        if isCodable && fieldsChangesSwaggerFieldNames {
+            model += decodeFunction(accessControl: accessControl).indentLines(1)
             model += "\n\n"
-            model += codingKeysFunction().indentLines(1)
+            model += encodeFunction(accessControl: accessControl).indentLines(1)
         }
 
         if embeddedDefinitions.count > 0 {
@@ -85,19 +82,44 @@ struct Model {
         return model
     }
 
-    private func codingKeysFunction() -> String {
-        let cases = fields.map { "case \($0.safeParameterName.value.variableNameFormatted) = \"\($0.argumentLabel)\"" }.joined(separator: "\n").indentLines(1)
+    private func encodeFunction(accessControl: APIAccessControl) -> String {
+        let encodeFields = fields.map {
+            let variableName = $0.safePropertyName.value.variableNameFormatted
+            let codingKey = $0.argumentLabel
+            let typeName = $0.type.toString(required: true)
+            let encodeIfPresent: String
+            if $0.isRequired == false || $0.defaultValue != nil {
+                encodeIfPresent = "IfPresent"
+            } else {
+                encodeIfPresent = ""
+            }
+
+            let defaultValue: String
+            if let defaultValueValue = $0.defaultValue {
+                defaultValue = " ?? \(defaultValueValue)"
+            } else {
+                defaultValue = ""
+            }
+
+            return "try container.encode\(encodeIfPresent)(\(variableName)\(defaultValue), forKey: \"\(codingKey)\")"
+        }.joined(separator: "\n")
+
+        let functionBody = """
+var container = encoder.container(keyedBy: StringCodingKey.self)
+\(encodeFields)
+"""
 
         return """
-        enum CodingKeys: String, CodingKey {
-        \(cases)
-        }
-        """
+\(accessControl.rawValue) func encode(to encoder: Encoder) throws {
+\(functionBody.indentLines(1))
+}
+"""
     }
 
-    private func decodeFunction() -> String {
+    private func decodeFunction(accessControl: APIAccessControl) -> String {
         let decodeFields = fields.map {
             let variableName = $0.safePropertyName.value.variableNameFormatted
+            let codingKey = $0.argumentLabel
             let typeName = $0.type.toString(required: true)
             let decodeIfPresent: String
             if $0.isRequired == false || $0.defaultValue != nil {
@@ -116,24 +138,24 @@ struct Model {
             if !$0.isRequired, typeName == "URL" {
                 return """
             // Allows the backend to return badly formatted urls
-            if let urlString = try container.decode\(decodeIfPresent)(String.self, forKey: .\(variableName))\(defaultValue) {
+            if let urlString = try container.decode\(decodeIfPresent)(String.self, forKey: \"\(codingKey)\")\(defaultValue) {
                 self.\(variableName) = URL(string: urlString)
             } else {
                 self.\(variableName) = nil
             }
             """
             } else {
-                return "self.\(variableName) = try container.decode\(decodeIfPresent)(\(typeName).self, forKey: .\(variableName))\(defaultValue)"
+                return "self.\(variableName) = try container.decode\(decodeIfPresent)(\(typeName).self, forKey: \"\(codingKey)\")\(defaultValue)"
             }
         }.joined(separator: "\n")
 
         let functionBody = """
-let container = try decoder.container(keyedBy: CodingKeys.self)
+let container = try decoder.container(keyedBy: StringCodingKey.self)
 \(decodeFields)
 """
 
         return """
-public init(from decoder: Decoder) throws {
+\(accessControl.rawValue)  init(from decoder: Decoder) throws {
 \(functionBody.indentLines(1))
 }
 """

--- a/Sources/SwaggerSwiftCore/Models/Model.swift
+++ b/Sources/SwaggerSwiftCore/Models/Model.swift
@@ -155,7 +155,7 @@ let container = try decoder.container(keyedBy: StringCodingKey.self)
 """
 
         return """
-\(accessControl.rawValue)  init(from decoder: Decoder) throws {
+\(accessControl.rawValue) init(from decoder: Decoder) throws {
 \(functionBody.indentLines(1))
 }
 """

--- a/Sources/SwaggerSwiftCore/Static Files/StringCodingKey.swift
+++ b/Sources/SwaggerSwiftCore/Static Files/StringCodingKey.swift
@@ -1,0 +1,29 @@
+let stringCodingKey = """
+import Foundation
+
+<ACCESSCONTROL> struct StringCodingKey: CodingKey, ExpressibleByStringLiteral {
+    private let string: String
+    private var int: Int?
+
+    <ACCESSCONTROL> var stringValue: String { return string }
+
+    <ACCESSCONTROL> init(string: String) {
+        self.string = string
+    }
+
+    <ACCESSCONTROL> init?(stringValue: String) {
+        self.string = stringValue
+    }
+
+    <ACCESSCONTROL> var intValue: Int? { return int }
+
+    <ACCESSCONTROL> init?(intValue: Int) {
+        self.string = String(describing: intValue)
+        self.int = intValue
+    }
+
+    <ACCESSCONTROL> init(stringLiteral value: String) {
+        self.string = value
+    }
+}
+"""

--- a/Tests/SwaggerSwiftCoreTests/SwaggerSwiftCoreTests.swift
+++ b/Tests/SwaggerSwiftCoreTests/SwaggerSwiftCoreTests.swift
@@ -22,13 +22,18 @@ public struct Test: Codable, Sendable {
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let container = try decoder.container(keyedBy: StringCodingKey.self)
         // Allows the backend to return badly formatted urls
-        if let urlString = try container.decodeIfPresent(String.self, forKey: .url) {
+        if let urlString = try container.decodeIfPresent(String.self, forKey: "url") {
             self.url = URL(string: urlString)
         } else {
             self.url = nil
         }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: StringCodingKey.self)
+        try container.encodeIfPresent(url, forKey: "url")
     }
 }
 """)
@@ -51,6 +56,16 @@ public struct Test: Codable, Sendable {
 
     public init(url: URL) {
         self.url = url
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: StringCodingKey.self)
+        self.url = try container.decode(URL.self, forKey: "url")
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: StringCodingKey.self)
+        try container.encode(url, forKey: "url")
     }
 }
 """)


### PR DESCRIPTION
See https://github.com/apple/swift/issues/60287 and https://github.com/CreateAPI/CreateAPI/issues/57 for more info. But in short apparently letting Xcode synthesize `Codable` conformance (more specifically `CodingKeys`) leads to binary size bloat. A simple solution is to create a custom `CodingKey` struct and then use strings instead of the enum cases in the `decode` methods.

Going from:
```
public init(from decoder: Decoder) throws {
            let container = try decoder.container(keyedBy: CodingKeys.self)
            self.deepLink = try container.decode(URL.self, forKey: .deepLink)
```

To:
```
public init(from decoder: Decoder) throws {
            let container = try decoder.container(keyedBy: StringCodingKey)
            self.deepLink = try container.decode(URL.self, forKey: "deepLink")
```

Fixes iOS-238
