### PR TITLE
HeaderProvider is async

### DIFF
--- a/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
@@ -207,7 +207,7 @@ struct APIFactory {
         if hasGlobalHeaders {
             fields.append(APIDefinitionField(name: "headerProvider",
                                              description: "a block provider for the set of globally defined headers",
-                                             typeName: "() -> any GlobalHeaders",
+                                             typeName: "() async -> any GlobalHeaders",
                                              isRequired: true,
                                              typeIsAutoclosure: false,
                                              typeIsBlock: true,

--- a/Sources/SwaggerSwiftCore/API Request Factory/Models/APIRequest+Swiftable.swift
+++ b/Sources/SwaggerSwiftCore/API Request Factory/Models/APIRequest+Swiftable.swift
@@ -35,7 +35,7 @@ extension APIRequest {
 
         var globalHeaders = [String]()
         if swaggerFile.globalHeaders.count > 0 {
-            globalHeaders.append("let globalHeaders = self.headerProvider()")
+            globalHeaders.append("let globalHeaders = await self.headerProvider()")
             globalHeaders.append("globalHeaders.add(to: &request)")
         }
 

--- a/Sources/SwaggerSwiftCore/Static Files/APIInitializeFile.swift
+++ b/Sources/SwaggerSwiftCore/Static Files/APIInitializeFile.swift
@@ -5,7 +5,7 @@ import Foundation
 public protocol APIInitialize {
     init(urlSession: @escaping () -> URLSession,
          baseUrlProvider: @escaping () -> URL,
-         headerProvider: @escaping () -> any GlobalHeaders,
+         headerProvider: @escaping () async -> any GlobalHeaders,
          interceptor: (any NetworkInterceptor)?
     )
 }


### PR DESCRIPTION
Usefull in cases where items used in the header are backed by an actor, and so requires async access.