### PR TITLE
:sparkles: Swift 6

### DIFF
--- a/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
@@ -186,41 +186,53 @@ struct APIFactory {
     /// - Returns: the model fields
     private func apiDefinitionsModelFields(swaggerFile: SwaggerFile) -> [APIDefinitionField] {
         var fields = [
-            APIDefinitionField(name: "urlSession",
-                               description: "the underlying URLSession. This is an autoclosure to allow updated instances to come into this instance.",
-                               typeName: "() -> URLSession",
-                               isRequired: true,
-                               typeIsAutoclosure: false,
-                               typeIsBlock: true,
-                               defaultValue: nil),
-            APIDefinitionField(name: "baseUrlProvider",
-                               description: "the block provider for the baseUrl of the service. The reason this is a block is that this enables automatically updating the network layer on backend environment change.",
-                               typeName: "() -> URL",
-                               isRequired: true,
-                               typeIsAutoclosure: false,
-                               typeIsBlock: true,
-                               defaultValue: nil)
+            APIDefinitionField(
+                name: "urlSession",
+                description: "the underlying URLSession. This is an autoclosure to allow updated instances to come into this instance.",
+                typeName: "() async -> URLSession",
+                isRequired: true,
+                typeIsAutoclosure: false,
+                typeIsBlock: true,
+                defaultValue: nil
+            ),
+            APIDefinitionField(
+                name: "baseUrlProvider",
+                description: "the block provider for the baseUrl of the service. The reason this is a block is that this enables automatically updating the network layer on backend environment change.",
+                typeName: "() async -> URL",
+                isRequired: true,
+                typeIsAutoclosure: false,
+                typeIsBlock: true,
+                defaultValue: nil
+            )
         ]
 
         let hasGlobalHeaders = swaggerFile.globalHeaders.count > 0
 
         if hasGlobalHeaders {
-            fields.append(APIDefinitionField(name: "headerProvider",
-                                             description: "a block provider for the set of globally defined headers",
-                                             typeName: "() async -> any GlobalHeaders",
-                                             isRequired: true,
-                                             typeIsAutoclosure: false,
-                                             typeIsBlock: true,
-                                             defaultValue: nil))
+            fields.append(
+                APIDefinitionField(
+                    name: "headerProvider",
+                    description: "a block provider for the set of globally defined headers",
+                    typeName: "() async -> any GlobalHeaders",
+                    isRequired: true,
+                    typeIsAutoclosure: false,
+                    typeIsBlock: true,
+                    defaultValue: nil
+                )
+            )
         }
 
-        fields.append(APIDefinitionField(name: "interceptor",
-                                         description: "use this if you need to intercept overall requests",
-                                         typeName: "(any NetworkInterceptor)",
-                                         isRequired: false,
-                                         typeIsAutoclosure: false,
-                                         typeIsBlock: false,
-                                         defaultValue: "nil"))
+        fields.append(
+            APIDefinitionField(
+                name: "interceptor",
+                description: "use this if you need to intercept overall requests",
+                typeName: "(any NetworkInterceptor)",
+                isRequired: false,
+                typeIsAutoclosure: false,
+                typeIsBlock: false,
+                defaultValue: "nil"
+            )
+        )
 
         return fields
     }

--- a/Sources/SwaggerSwiftCore/API Factory/Models/APIDefinition.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/Models/APIDefinition.swift
@@ -27,7 +27,7 @@ struct APIDefinition {
         }
 
         let properties = fields
-            .map { "private let \($0.name): \($0.typeName)\($0.isRequired ? "" : "?")" }
+            .map { "private let \($0.name): \($0.typeIsBlock ? "@Sendable " : "")\($0.typeName)\($0.isRequired ? "" : "?")" }
             .joined(separator: "\n")
             .indentLines(1)
 
@@ -44,7 +44,7 @@ struct APIDefinition {
             .trimmingCharacters(in: CharacterSet.newlines)
 
         serviceDefinition += """
-\(accessControl) struct \(serviceName): @unchecked Sendable, APIInitialize {
+\(accessControl) struct \(serviceName): APIInitialize {
 \(properties)
 
 \(initMethod)

--- a/Sources/SwaggerSwiftCore/API Factory/Models/APIDefinitionField.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/Models/APIDefinitionField.swift
@@ -8,14 +8,14 @@ struct APIDefinitionField {
     let defaultValue: String?
 
     var documentationString: String {
-        return "///   - \(name): \(description ?? "")"
+        "///   - \(name): \(description ?? "")"
     }
 
     var initProperty: String {
-        return "\(name): \(typeIsAutoclosure ? "@autoclosure " : "")\(typeIsBlock ? "@escaping " : "")\(typeName)\(isRequired ? "" : "?")\(defaultValue != nil ? " = \(defaultValue!)" : "")"
+        "\(name): \(typeIsAutoclosure ? "@autoclosure " : "")\(typeIsBlock ? "@escaping @Sendable" : "")\(typeName)\(isRequired ? "" : "?")\(defaultValue != nil ? " = \(defaultValue!)" : "")"
     }
 
     var initAssignment: String {
-        return "self.\(name) = \(name)"
+        "self.\(name) = \(name)"
     }
 }

--- a/Sources/SwaggerSwiftCore/Static Files/APIInitializeFile.swift
+++ b/Sources/SwaggerSwiftCore/Static Files/APIInitializeFile.swift
@@ -3,9 +3,9 @@ import Foundation
 
 /// Provides a single common interface for initialising all APIs
 public protocol APIInitialize {
-    init(urlSession: @escaping () -> URLSession,
-         baseUrlProvider: @escaping () -> URL,
-         headerProvider: @escaping () async -> any GlobalHeaders,
+    init(urlSession: @escaping @Sendable () async -> URLSession,
+         baseUrlProvider: @escaping @Sendable () async -> URL,
+         headerProvider: @escaping @Sendable () async -> any GlobalHeaders,
          interceptor: (any NetworkInterceptor)?
     )
 }

--- a/Sources/SwaggerSwiftCore/Static Files/NetworkInterceptorProtocolFile.swift
+++ b/Sources/SwaggerSwiftCore/Static Files/NetworkInterceptorProtocolFile.swift
@@ -1,8 +1,11 @@
 let networkInterceptor = """
 import Foundation
 
-public protocol NetworkInterceptor {
-    func networkWillPerformRequest(_ request: URLRequest) -> URLRequest
+public protocol NetworkInterceptor: Sendable {
+    func networkWillPerformRequest(
+        _ request: URLRequest
+    ) -> URLRequest
+
     /// Called when a request has been made. Use this to intercept any response to perform some other behaviour. If the function throws an error, it will
     /// push the error back to the response callsite.
     /// - Parameters:
@@ -10,14 +13,26 @@ public protocol NetworkInterceptor {
     ///   - urlResponse: the response object
     ///   - data: the data received, if any
     ///   - error: the error, if any
-    func networkDidPerformRequest(urlRequest: URLRequest, urlResponse: URLResponse?, data: Data?, error: Error?) async throws
-    /// Called when the network fails to parse a response object as based on the Swagger spec. This probably means that the Swagger spec is in-compliant with the actual API.
+    func networkDidPerformRequest(
+        urlRequest: URLRequest,
+        urlResponse: URLResponse?,
+        data: Data?,
+        error: Error?
+    ) async throws
+
+    /// Called when the network fails to parse a response object as based on the Swagger spec.
+    /// This probably means that the Swagger spec is in-compliant with the actual API.
     /// - Parameters:
     ///   - urlRequest: the URLRequest
     ///   - urlResponse: the URLResponse
     ///   - data: the payload
     ///   - error: the parsing error
-    func networkFailedToParseObject(urlRequest: URLRequest, urlResponse: URLResponse?, data: Data?, error: Error?)
+    func networkFailedToParseObject(
+        urlRequest: URLRequest,
+        urlResponse: URLResponse?,
+        data: Data?,
+        error: Error?
+    )
 }
 
 """

--- a/Sources/SwaggerSwiftCore/SwaggerFile Parser/Models/SwaggerFile.swift
+++ b/Sources/SwaggerSwiftCore/SwaggerFile Parser/Models/SwaggerFile.swift
@@ -15,6 +15,7 @@ struct SwaggerFile: Decodable {
     /// Where should the project be created?
     let destination: String
     let accessControl: APIAccessControl
+    let onlyAsync: Bool
 
     enum CodingKeys: String, CodingKey {
         case path
@@ -25,6 +26,7 @@ struct SwaggerFile: Decodable {
         case createSwiftPackage
         case projectName
         case destination
+        case onlyAsync
     }
 
     init(
@@ -35,7 +37,8 @@ struct SwaggerFile: Decodable {
         createSwiftPackage: Bool = true,
         accessControl: APIAccessControl = .public,
         destination: String = "./",
-        projectName: String = "Services"
+        projectName: String = "Services",
+        onlyAsync: Bool
     ) {
         self.path = path
         self.organisation = organisation
@@ -45,6 +48,7 @@ struct SwaggerFile: Decodable {
         self.createSwiftPackage = createSwiftPackage
         self.destination = destination
         self.projectName = projectName
+        self.onlyAsync = onlyAsync
     }
 
     init(from decoder: Decoder) throws {
@@ -57,6 +61,7 @@ struct SwaggerFile: Decodable {
         self.createSwiftPackage = try container.decodeIfPresent(Bool.self, forKey: .createSwiftPackage) ?? true
         self.projectName = try container.decodeIfPresent(String.self, forKey: .projectName) ?? "Services"
         self.destination = try container.decodeIfPresent(String.self, forKey: .destination) ?? "./"
+        self.onlyAsync = try container.decodeIfPresent(Bool.self, forKey: .onlyAsync) ?? true
     }
 
     struct Service: Decodable {


### PR DESCRIPTION
Adding new field to SwaggerFile: `onlyAsync`. Default SwaggerSwift will no longer generate completion handler based API's but only async. This can be deactivated by setting the flag to false.

`@unchecked Sendable` has also been removed from the API and instead of all blocks is no @Sendable.