### PR TITLE
:sparkles: Support global primitives

### DIFF
--- a/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
@@ -2,265 +2,271 @@ import Foundation
 import SwaggerSwiftML
 
 struct APIFactory {
-  let apiRequestFactory: APIRequestFactory
-  let modelTypeResolver: ModelTypeResolver
+    let apiRequestFactory: APIRequestFactory
+    let modelTypeResolver: ModelTypeResolver
 
-  func generate(for swagger: Swagger, withSwaggerFile swaggerFile: SwaggerFile) throws -> (
-    APIDefinition, [ModelDefinition]
-  ) {
-    let (apiFunctions, inlineModelDefinitions) = try getApiList(
-      fromSwagger: swagger, swaggerFile: swaggerFile)
-    let modelDefinitions = try getModelDefinitions(fromSwagger: swagger)
-    let responseModelDefinitions = try getResponseModelDefinitions(fromSwagger: swagger)
+    func generate(for swagger: Swagger, withSwaggerFile swaggerFile: SwaggerFile) throws -> (
+        APIDefinition, [ModelDefinition]
+    ) {
+        let (apiFunctions, inlineModelDefinitions) = try getApiList(
+            fromSwagger: swagger, swaggerFile: swaggerFile)
+        let modelDefinitions = try getModelDefinitions(fromSwagger: swagger)
+        let responseModelDefinitions = try getResponseModelDefinitions(fromSwagger: swagger)
 
-    // Model Definitions can be a lot of things - when resolving the inheritance tree for
-    // the model definitions we just need the actual models, and a model can only inherit
-    // from the global swagger model definitions
-    let models = modelDefinitions.compactMap { model -> Model? in
-      if case let ModelDefinition.object(model) = model {
-        return model
-      } else {
-        return nil
-      }
-    }
-
-    let totalSetOfModelDefinitions = modelDefinitions + inlineModelDefinitions
-    let resolvedModelDefinitions = totalSetOfModelDefinitions.map {
-      $0.resolveInheritanceTree(with: models)
-    }
-    let allModelDefinitions = resolvedModelDefinitions + responseModelDefinitions
-
-    let apiDefinitionFields = apiDefinitionsModelFields(swaggerFile: swaggerFile)
-
-    let apiDefinition = APIDefinition(
-      serviceName: swagger.serviceName,
-      description: swagger.info.description?.trimmingCharacters(
-        in: CharacterSet.whitespacesAndNewlines),
-      fields: apiDefinitionFields,
-      functions: apiFunctions
-    )
-
-    return (apiDefinition, allModelDefinitions)
-  }
-
-  /// Parse all service paths in the swagger - get the request function models, and all the inline model definitions
-  /// - Parameter swagger: the swagger
-  /// - Parameter swaggerFile: the swagger file
-  /// - Returns: the list of APIs and any inline model definitions found in the paths
-  private func getApiList(fromSwagger swagger: Swagger, swaggerFile: SwaggerFile) throws -> (
-    [APIRequest], [ModelDefinition]
-  ) {
-    var networkRequestFunctions = [APIRequest]()
-    var inlineModelDefinitions = [ModelDefinition]()
-    for swaggerPath in swagger.paths {
-      let (pathNetworkRequestFunctions, pathCurrentInlineDefinitions) = try apisAndModels(
-        fromPath: swaggerPath.value,
-        servicePath: swaggerPath.key,
-        swagger: swagger,
-        swaggerFile: swaggerFile
-      )
-
-      networkRequestFunctions.append(contentsOf: pathNetworkRequestFunctions)
-      inlineModelDefinitions.append(contentsOf: pathCurrentInlineDefinitions)
-    }
-
-    return (networkRequestFunctions, inlineModelDefinitions)
-  }
-
-  func apisAndModels(
-    fromPath path: SwaggerSwiftML.Path, servicePath: String, swagger: Swagger,
-    swaggerFile: SwaggerFile
-  ) throws -> ([APIRequest], [ModelDefinition]) {
-    var apis = [APIRequest]()
-    var modelDefinitions = [ModelDefinition]()
-
-    let parameters: [Parameter] = try (path.parameters ?? []).map(swagger.findParameter(node:))
-
-    for httpMethod in HTTPMethod.allCases {
-      guard let operation = path.operationForMethod(httpMethod)
-      else { continue }
-
-      let (requestFunctions, inlineModelDefinitions) = try apiRequestFactory.generateRequest(
-        for: operation,
-        httpMethod: httpMethod,
-        servicePath: servicePath,
-        swagger: swagger,
-        swaggerFile: swaggerFile,
-        pathParameters: parameters
-      )
-
-      apis.append(requestFunctions)
-      modelDefinitions.append(contentsOf: inlineModelDefinitions)
-    }
-
-    return (apis, modelDefinitions)
-  }
-
-  /// Get the global set of model definitions. This is the normal specified list, and not the inline definitions that are defined in e.g. path definitions and other places
-  /// - Parameter swagger: the swagger
-  /// - Returns: model definitions
-  private func getModelDefinitions(fromSwagger swagger: Swagger) throws -> [ModelDefinition] {
-    guard let definitions = swagger.definitions else {
-      return []
-    }
-
-    var allDefinitions = [ModelDefinition]()
-    for (typeName, schema) in definitions {
-      let resolved = try modelTypeResolver.resolve(
-        forSchema: schema,
-        typeNamePrefix: typeName,
-        namespace: swagger.serviceName,
-        swagger: swagger)
-
-      allDefinitions.append(contentsOf: resolved.inlineModelDefinitions)
-
-      switch resolved.propertyType {
-      case .typeAlias(let typeName, let type):
-        allDefinitions.append(
-          .typeAlias(.init(typeName: typeName, type: type.toString(required: true))))
-      case .array(let containsType):
-        let arrayModel = ModelDefinition.array(
-          .init(
-            description: schema.description, typeName: typeName,
-            containsType: containsType.toString(required: true)))
-        allDefinitions.append(arrayModel)
-      case .string:
-        break
-      case .int:
-        break
-      case .double:
-        break
-      case .float:
-        break
-      case .boolean:
-        break
-      case .int64:
-        break
-      case .date:
-        break
-      case .void:
-        break
-      case .object:
-        break
-      case .enumeration:
-        break
-      }
-    }
-
-    return allDefinitions
-  }
-
-  /// Get the global set of response model definitions
-  /// - Parameter swagger: the swagger
-  /// - Returns: the set of global response model definitions
-  private func getResponseModelDefinitions(fromSwagger swagger: Swagger) throws -> [ModelDefinition]
-  {
-    var modelDefinitions = [ModelDefinition]()
-    for (typeName, response) in swagger.responses ?? [:] {
-      guard let schema = response.schema else {
-        if response.headers != nil {
-          log(
-            "SwaggerSwift does currently not support models without schema but with defined headers"
-          )
-          /// TODO: Add support for this
-          /// Example:
-          ///  RedirectResponse:
-          ///    description: Response used to redirect the client to Location
-          ///    headers:
-          ///      Location:
-          ///        type: string
+        // Model Definitions can be a lot of things - when resolving the inheritance tree for
+        // the model definitions we just need the actual models, and a model can only inherit
+        // from the global swagger model definitions
+        let models = modelDefinitions.compactMap { model -> Model? in
+            if case let ModelDefinition.object(model) = model {
+                return model
+            } else {
+                return nil
+            }
         }
 
-        continue
-      }
-
-      switch schema {
-      case .reference(let reference):
-        if let (_, typeSchema) = swagger.definitions?.first(where: {
-          reference == "#/definitions/\($0.key)"
-        }) {
-          // we dont need the type part as it just represents the primary model definition returned from this function
-          let resolvedModel = try modelTypeResolver.resolve(
-            forSchema: typeSchema,
-            typeNamePrefix: typeName,
-            namespace: swagger.serviceName,
-            swagger: swagger)
-          modelDefinitions.append(contentsOf: resolvedModel.inlineModelDefinitions)
-        } else {
-          log(
-            "[\(swagger.serviceName)] Failed to find definition for reference: \(reference)",
-            error: true)
-          continue
+        let totalSetOfModelDefinitions = modelDefinitions + inlineModelDefinitions
+        let resolvedModelDefinitions = totalSetOfModelDefinitions.map {
+            $0.resolveInheritanceTree(with: models)
         }
-      case .node(let schema):
-        // we dont need the type part as it just represents the primary model definition returned from this function
-        let resolvedModel = try modelTypeResolver.resolve(
-          forSchema: schema,
-          typeNamePrefix: typeName,
-          namespace: swagger.serviceName,
-          swagger: swagger)
-        modelDefinitions.append(contentsOf: resolvedModel.inlineModelDefinitions)
-      }
-    }
+        let allModelDefinitions = resolvedModelDefinitions + responseModelDefinitions
 
-    return modelDefinitions
-  }
+        let apiDefinitionFields = apiDefinitionsModelFields(swaggerFile: swaggerFile)
 
-  /// The model fields for the API definition
-  /// - Parameter swaggerFile: the swagger file
-  /// - Returns: the model fields
-  private func apiDefinitionsModelFields(swaggerFile: SwaggerFile) -> [APIDefinitionField] {
-    var fields = [
-      APIDefinitionField(
-        name: "urlSession",
-        description:
-          "the underlying URLSession. This is an autoclosure to allow updated instances to come into this instance.",
-        typeName: "() async -> URLSession",
-        isRequired: true,
-        typeIsAutoclosure: false,
-        typeIsBlock: true,
-        defaultValue: nil
-      ),
-      APIDefinitionField(
-        name: "baseUrlProvider",
-        description:
-          "the block provider for the baseUrl of the service. The reason this is a block is that this enables automatically updating the network layer on backend environment change.",
-        typeName: "() async -> URL",
-        isRequired: true,
-        typeIsAutoclosure: false,
-        typeIsBlock: true,
-        defaultValue: nil
-      ),
-    ]
-
-    let hasGlobalHeaders = swaggerFile.globalHeaders.count > 0
-
-    if hasGlobalHeaders {
-      fields.append(
-        APIDefinitionField(
-          name: "headerProvider",
-          description: "a block provider for the set of globally defined headers",
-          typeName: "() async -> any GlobalHeaders",
-          isRequired: true,
-          typeIsAutoclosure: false,
-          typeIsBlock: true,
-          defaultValue: nil
+        let apiDefinition = APIDefinition(
+            serviceName: swagger.serviceName,
+            description: swagger.info.description?.trimmingCharacters(
+                in: CharacterSet.whitespacesAndNewlines),
+            fields: apiDefinitionFields,
+            functions: apiFunctions
         )
-      )
+
+        return (apiDefinition, allModelDefinitions)
     }
 
-    fields.append(
-      APIDefinitionField(
-        name: "interceptor",
-        description: "use this if you need to intercept overall requests",
-        typeName: "(any NetworkInterceptor)",
-        isRequired: false,
-        typeIsAutoclosure: false,
-        typeIsBlock: false,
-        defaultValue: "nil"
-      )
-    )
+    /// Parse all service paths in the swagger - get the request function models, and all the inline model definitions
+    /// - Parameter swagger: the swagger
+    /// - Parameter swaggerFile: the swagger file
+    /// - Returns: the list of APIs and any inline model definitions found in the paths
+    private func getApiList(fromSwagger swagger: Swagger, swaggerFile: SwaggerFile) throws -> (
+        [APIRequest], [ModelDefinition]
+    ) {
+        var networkRequestFunctions = [APIRequest]()
+        var inlineModelDefinitions = [ModelDefinition]()
+        for swaggerPath in swagger.paths {
+            let (pathNetworkRequestFunctions, pathCurrentInlineDefinitions) = try apisAndModels(
+                fromPath: swaggerPath.value,
+                servicePath: swaggerPath.key,
+                swagger: swagger,
+                swaggerFile: swaggerFile
+            )
 
-    return fields
-  }
+            networkRequestFunctions.append(contentsOf: pathNetworkRequestFunctions)
+            inlineModelDefinitions.append(contentsOf: pathCurrentInlineDefinitions)
+        }
+
+        return (networkRequestFunctions, inlineModelDefinitions)
+    }
+
+    func apisAndModels(
+        fromPath path: SwaggerSwiftML.Path, servicePath: String, swagger: Swagger,
+        swaggerFile: SwaggerFile
+    ) throws -> ([APIRequest], [ModelDefinition]) {
+        var apis = [APIRequest]()
+        var modelDefinitions = [ModelDefinition]()
+
+        let parameters: [Parameter] = try (path.parameters ?? []).map(swagger.findParameter(node:))
+
+        for httpMethod in HTTPMethod.allCases {
+            guard let operation = path.operationForMethod(httpMethod)
+            else { continue }
+
+            let (requestFunctions, inlineModelDefinitions) = try apiRequestFactory.generateRequest(
+                for: operation,
+                httpMethod: httpMethod,
+                servicePath: servicePath,
+                swagger: swagger,
+                swaggerFile: swaggerFile,
+                pathParameters: parameters
+            )
+
+            apis.append(requestFunctions)
+            modelDefinitions.append(contentsOf: inlineModelDefinitions)
+        }
+
+        return (apis, modelDefinitions)
+    }
+
+    /// Get the global set of model definitions. This is the normal specified list, and not the inline definitions that are defined in e.g. path definitions and other places
+    /// - Parameter swagger: the swagger
+    /// - Returns: model definitions
+    private func getModelDefinitions(fromSwagger swagger: Swagger) throws -> [ModelDefinition] {
+        guard let definitions = swagger.definitions else {
+            return []
+        }
+
+        var allDefinitions = [ModelDefinition]()
+        for (typeName, schema) in definitions {
+            let resolved = try modelTypeResolver.resolve(
+                forSchema: schema,
+                typeNamePrefix: typeName,
+                namespace: swagger.serviceName,
+                swagger: swagger)
+
+            allDefinitions.append(contentsOf: resolved.inlineModelDefinitions)
+
+            switch resolved.propertyType {
+            case .typeAlias(let typeName, let type):
+                allDefinitions.append(
+                    .typeAlias(.init(typeName: typeName, type: type.toString(required: true))))
+            case .array(let containsType):
+                let arrayModel = ModelDefinition.array(
+                    .init(
+                        description: schema.description, typeName: typeName,
+                        containsType: containsType.toString(required: true)))
+                allDefinitions.append(arrayModel)
+            case .string:
+                allDefinitions.append(
+                    .typeAlias(.init(typeName: typeName, type: "String")))
+            case .int:
+                allDefinitions.append(
+                    .typeAlias(.init(typeName: typeName, type: "Int")))
+            case .double:
+                allDefinitions.append(
+                    .typeAlias(.init(typeName: typeName, type: "Double")))
+            case .float:
+                allDefinitions.append(
+                    .typeAlias(.init(typeName: typeName, type: "Double")))
+            case .boolean:
+                allDefinitions.append(
+                    .typeAlias(.init(typeName: typeName, type: "Bool")))
+            case .int64:
+                allDefinitions.append(
+                    .typeAlias(.init(typeName: typeName, type: "Int64")))
+            case .date:
+                allDefinitions.append(
+                    .typeAlias(.init(typeName: typeName, type: "Date")))
+            case .void:
+                allDefinitions.append(
+                    .typeAlias(.init(typeName: typeName, type: "Void")))
+            case .object: break
+            case .enumeration: break
+            }
+        }
+
+        return allDefinitions
+    }
+
+    /// Get the global set of response model definitions
+    /// - Parameter swagger: the swagger
+    /// - Returns: the set of global response model definitions
+    private func getResponseModelDefinitions(fromSwagger swagger: Swagger) throws -> [ModelDefinition]
+    {
+        var modelDefinitions = [ModelDefinition]()
+        for (typeName, response) in swagger.responses ?? [:] {
+            guard let schema = response.schema else {
+                if response.headers != nil {
+                    log(
+                        "SwaggerSwift does currently not support models without schema but with defined headers"
+                    )
+                    /// TODO: Add support for this
+                    /// Example:
+                    ///  RedirectResponse:
+                    ///    description: Response used to redirect the client to Location
+                    ///    headers:
+                    ///      Location:
+                    ///        type: string
+                }
+
+                continue
+            }
+
+            switch schema {
+            case .reference(let reference):
+                if let (_, typeSchema) = swagger.definitions?.first(where: {
+                    reference == "#/definitions/\($0.key)"
+                }) {
+                    // we dont need the type part as it just represents the primary model definition returned from this function
+                    let resolvedModel = try modelTypeResolver.resolve(
+                        forSchema: typeSchema,
+                        typeNamePrefix: typeName,
+                        namespace: swagger.serviceName,
+                        swagger: swagger)
+                    modelDefinitions.append(contentsOf: resolvedModel.inlineModelDefinitions)
+                } else {
+                    log(
+                        "[\(swagger.serviceName)] Failed to find definition for reference: \(reference)",
+                        error: true)
+                    continue
+                }
+            case .node(let schema):
+                // we dont need the type part as it just represents the primary model definition returned from this function
+                let resolvedModel = try modelTypeResolver.resolve(
+                    forSchema: schema,
+                    typeNamePrefix: typeName,
+                    namespace: swagger.serviceName,
+                    swagger: swagger)
+                modelDefinitions.append(contentsOf: resolvedModel.inlineModelDefinitions)
+            }
+        }
+
+        return modelDefinitions
+    }
+
+    /// The model fields for the API definition
+    /// - Parameter swaggerFile: the swagger file
+    /// - Returns: the model fields
+    private func apiDefinitionsModelFields(swaggerFile: SwaggerFile) -> [APIDefinitionField] {
+        var fields = [
+            APIDefinitionField(
+                name: "urlSession",
+                description:
+                    "the underlying URLSession. This is an autoclosure to allow updated instances to come into this instance.",
+                typeName: "() async -> URLSession",
+                isRequired: true,
+                typeIsAutoclosure: false,
+                typeIsBlock: true,
+                defaultValue: nil
+            ),
+            APIDefinitionField(
+                name: "baseUrlProvider",
+                description:
+                    "the block provider for the baseUrl of the service. The reason this is a block is that this enables automatically updating the network layer on backend environment change.",
+                typeName: "() async -> URL",
+                isRequired: true,
+                typeIsAutoclosure: false,
+                typeIsBlock: true,
+                defaultValue: nil
+            ),
+        ]
+
+        let hasGlobalHeaders = swaggerFile.globalHeaders.count > 0
+
+        if hasGlobalHeaders {
+            fields.append(
+                APIDefinitionField(
+                    name: "headerProvider",
+                    description: "a block provider for the set of globally defined headers",
+                    typeName: "() async -> any GlobalHeaders",
+                    isRequired: true,
+                    typeIsAutoclosure: false,
+                    typeIsBlock: true,
+                    defaultValue: nil
+                )
+            )
+        }
+
+        fields.append(
+            APIDefinitionField(
+                name: "interceptor",
+                description: "use this if you need to intercept overall requests",
+                typeName: "(any NetworkInterceptor)",
+                isRequired: false,
+                typeIsAutoclosure: false,
+                typeIsBlock: false,
+                defaultValue: "nil"
+            )
+        )
+
+        return fields
+    }
 }

--- a/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
+++ b/Sources/SwaggerSwiftCore/API Factory/APIFactory.swift
@@ -2,271 +2,271 @@ import Foundation
 import SwaggerSwiftML
 
 struct APIFactory {
-    let apiRequestFactory: APIRequestFactory
-    let modelTypeResolver: ModelTypeResolver
+  let apiRequestFactory: APIRequestFactory
+  let modelTypeResolver: ModelTypeResolver
 
-    func generate(for swagger: Swagger, withSwaggerFile swaggerFile: SwaggerFile) throws -> (
-        APIDefinition, [ModelDefinition]
-    ) {
-        let (apiFunctions, inlineModelDefinitions) = try getApiList(
-            fromSwagger: swagger, swaggerFile: swaggerFile)
-        let modelDefinitions = try getModelDefinitions(fromSwagger: swagger)
-        let responseModelDefinitions = try getResponseModelDefinitions(fromSwagger: swagger)
+  func generate(for swagger: Swagger, withSwaggerFile swaggerFile: SwaggerFile) throws -> (
+    APIDefinition, [ModelDefinition]
+  ) {
+    let (apiFunctions, inlineModelDefinitions) = try getApiList(
+      fromSwagger: swagger, swaggerFile: swaggerFile)
+    let modelDefinitions = try getModelDefinitions(fromSwagger: swagger)
+    let responseModelDefinitions = try getResponseModelDefinitions(fromSwagger: swagger)
 
-        // Model Definitions can be a lot of things - when resolving the inheritance tree for
-        // the model definitions we just need the actual models, and a model can only inherit
-        // from the global swagger model definitions
-        let models = modelDefinitions.compactMap { model -> Model? in
-            if case let ModelDefinition.object(model) = model {
-                return model
-            } else {
-                return nil
-            }
+    // Model Definitions can be a lot of things - when resolving the inheritance tree for
+    // the model definitions we just need the actual models, and a model can only inherit
+    // from the global swagger model definitions
+    let models = modelDefinitions.compactMap { model -> Model? in
+      if case let ModelDefinition.object(model) = model {
+        return model
+      } else {
+        return nil
+      }
+    }
+
+    let totalSetOfModelDefinitions = modelDefinitions + inlineModelDefinitions
+    let resolvedModelDefinitions = totalSetOfModelDefinitions.map {
+      $0.resolveInheritanceTree(with: models)
+    }
+    let allModelDefinitions = resolvedModelDefinitions + responseModelDefinitions
+
+    let apiDefinitionFields = apiDefinitionsModelFields(swaggerFile: swaggerFile)
+
+    let apiDefinition = APIDefinition(
+      serviceName: swagger.serviceName,
+      description: swagger.info.description?.trimmingCharacters(
+        in: CharacterSet.whitespacesAndNewlines),
+      fields: apiDefinitionFields,
+      functions: apiFunctions
+    )
+
+    return (apiDefinition, allModelDefinitions)
+  }
+
+  /// Parse all service paths in the swagger - get the request function models, and all the inline model definitions
+  /// - Parameter swagger: the swagger
+  /// - Parameter swaggerFile: the swagger file
+  /// - Returns: the list of APIs and any inline model definitions found in the paths
+  private func getApiList(fromSwagger swagger: Swagger, swaggerFile: SwaggerFile) throws -> (
+    [APIRequest], [ModelDefinition]
+  ) {
+    var networkRequestFunctions = [APIRequest]()
+    var inlineModelDefinitions = [ModelDefinition]()
+    for swaggerPath in swagger.paths {
+      let (pathNetworkRequestFunctions, pathCurrentInlineDefinitions) = try apisAndModels(
+        fromPath: swaggerPath.value,
+        servicePath: swaggerPath.key,
+        swagger: swagger,
+        swaggerFile: swaggerFile
+      )
+
+      networkRequestFunctions.append(contentsOf: pathNetworkRequestFunctions)
+      inlineModelDefinitions.append(contentsOf: pathCurrentInlineDefinitions)
+    }
+
+    return (networkRequestFunctions, inlineModelDefinitions)
+  }
+
+  func apisAndModels(
+    fromPath path: SwaggerSwiftML.Path, servicePath: String, swagger: Swagger,
+    swaggerFile: SwaggerFile
+  ) throws -> ([APIRequest], [ModelDefinition]) {
+    var apis = [APIRequest]()
+    var modelDefinitions = [ModelDefinition]()
+
+    let parameters: [Parameter] = try (path.parameters ?? []).map(swagger.findParameter(node:))
+
+    for httpMethod in HTTPMethod.allCases {
+      guard let operation = path.operationForMethod(httpMethod)
+      else { continue }
+
+      let (requestFunctions, inlineModelDefinitions) = try apiRequestFactory.generateRequest(
+        for: operation,
+        httpMethod: httpMethod,
+        servicePath: servicePath,
+        swagger: swagger,
+        swaggerFile: swaggerFile,
+        pathParameters: parameters
+      )
+
+      apis.append(requestFunctions)
+      modelDefinitions.append(contentsOf: inlineModelDefinitions)
+    }
+
+    return (apis, modelDefinitions)
+  }
+
+  /// Get the global set of model definitions. This is the normal specified list, and not the inline definitions that are defined in e.g. path definitions and other places
+  /// - Parameter swagger: the swagger
+  /// - Returns: model definitions
+  private func getModelDefinitions(fromSwagger swagger: Swagger) throws -> [ModelDefinition] {
+    guard let definitions = swagger.definitions else {
+      return []
+    }
+
+    var allDefinitions = [ModelDefinition]()
+    for (typeName, schema) in definitions {
+      let resolved = try modelTypeResolver.resolve(
+        forSchema: schema,
+        typeNamePrefix: typeName,
+        namespace: swagger.serviceName,
+        swagger: swagger)
+
+      allDefinitions.append(contentsOf: resolved.inlineModelDefinitions)
+
+      switch resolved.propertyType {
+      case .typeAlias(let typeName, let type):
+        allDefinitions.append(
+          .typeAlias(.init(typeName: typeName, type: type.toString(required: true))))
+      case .array(let containsType):
+        let arrayModel = ModelDefinition.array(
+          .init(
+            description: schema.description, typeName: typeName,
+            containsType: containsType.toString(required: true)))
+        allDefinitions.append(arrayModel)
+      case .string:
+        allDefinitions.append(
+          .typeAlias(.init(typeName: typeName, type: "String")))
+      case .int:
+        allDefinitions.append(
+          .typeAlias(.init(typeName: typeName, type: "Int")))
+      case .double:
+        allDefinitions.append(
+          .typeAlias(.init(typeName: typeName, type: "Double")))
+      case .float:
+        allDefinitions.append(
+          .typeAlias(.init(typeName: typeName, type: "Double")))
+      case .boolean:
+        allDefinitions.append(
+          .typeAlias(.init(typeName: typeName, type: "Bool")))
+      case .int64:
+        allDefinitions.append(
+          .typeAlias(.init(typeName: typeName, type: "Int64")))
+      case .date:
+        allDefinitions.append(
+          .typeAlias(.init(typeName: typeName, type: "Date")))
+      case .void:
+        allDefinitions.append(
+          .typeAlias(.init(typeName: typeName, type: "Void")))
+      case .object: break
+      case .enumeration: break
+      }
+    }
+
+    return allDefinitions
+  }
+
+  /// Get the global set of response model definitions
+  /// - Parameter swagger: the swagger
+  /// - Returns: the set of global response model definitions
+  private func getResponseModelDefinitions(fromSwagger swagger: Swagger) throws -> [ModelDefinition]
+  {
+    var modelDefinitions = [ModelDefinition]()
+    for (typeName, response) in swagger.responses ?? [:] {
+      guard let schema = response.schema else {
+        if response.headers != nil {
+          log(
+            "SwaggerSwift does currently not support models without schema but with defined headers"
+          )
+          /// TODO: Add support for this
+          /// Example:
+          ///  RedirectResponse:
+          ///    description: Response used to redirect the client to Location
+          ///    headers:
+          ///      Location:
+          ///        type: string
         }
 
-        let totalSetOfModelDefinitions = modelDefinitions + inlineModelDefinitions
-        let resolvedModelDefinitions = totalSetOfModelDefinitions.map {
-            $0.resolveInheritanceTree(with: models)
+        continue
+      }
+
+      switch schema {
+      case .reference(let reference):
+        if let (_, typeSchema) = swagger.definitions?.first(where: {
+          reference == "#/definitions/\($0.key)"
+        }) {
+          // we dont need the type part as it just represents the primary model definition returned from this function
+          let resolvedModel = try modelTypeResolver.resolve(
+            forSchema: typeSchema,
+            typeNamePrefix: typeName,
+            namespace: swagger.serviceName,
+            swagger: swagger)
+          modelDefinitions.append(contentsOf: resolvedModel.inlineModelDefinitions)
+        } else {
+          log(
+            "[\(swagger.serviceName)] Failed to find definition for reference: \(reference)",
+            error: true)
+          continue
         }
-        let allModelDefinitions = resolvedModelDefinitions + responseModelDefinitions
+      case .node(let schema):
+        // we dont need the type part as it just represents the primary model definition returned from this function
+        let resolvedModel = try modelTypeResolver.resolve(
+          forSchema: schema,
+          typeNamePrefix: typeName,
+          namespace: swagger.serviceName,
+          swagger: swagger)
+        modelDefinitions.append(contentsOf: resolvedModel.inlineModelDefinitions)
+      }
+    }
 
-        let apiDefinitionFields = apiDefinitionsModelFields(swaggerFile: swaggerFile)
+    return modelDefinitions
+  }
 
-        let apiDefinition = APIDefinition(
-            serviceName: swagger.serviceName,
-            description: swagger.info.description?.trimmingCharacters(
-                in: CharacterSet.whitespacesAndNewlines),
-            fields: apiDefinitionFields,
-            functions: apiFunctions
+  /// The model fields for the API definition
+  /// - Parameter swaggerFile: the swagger file
+  /// - Returns: the model fields
+  private func apiDefinitionsModelFields(swaggerFile: SwaggerFile) -> [APIDefinitionField] {
+    var fields = [
+      APIDefinitionField(
+        name: "urlSession",
+        description:
+          "the underlying URLSession. This is an autoclosure to allow updated instances to come into this instance.",
+        typeName: "() async -> URLSession",
+        isRequired: true,
+        typeIsAutoclosure: false,
+        typeIsBlock: true,
+        defaultValue: nil
+      ),
+      APIDefinitionField(
+        name: "baseUrlProvider",
+        description:
+          "the block provider for the baseUrl of the service. The reason this is a block is that this enables automatically updating the network layer on backend environment change.",
+        typeName: "() async -> URL",
+        isRequired: true,
+        typeIsAutoclosure: false,
+        typeIsBlock: true,
+        defaultValue: nil
+      ),
+    ]
+
+    let hasGlobalHeaders = swaggerFile.globalHeaders.count > 0
+
+    if hasGlobalHeaders {
+      fields.append(
+        APIDefinitionField(
+          name: "headerProvider",
+          description: "a block provider for the set of globally defined headers",
+          typeName: "() async -> any GlobalHeaders",
+          isRequired: true,
+          typeIsAutoclosure: false,
+          typeIsBlock: true,
+          defaultValue: nil
         )
-
-        return (apiDefinition, allModelDefinitions)
+      )
     }
 
-    /// Parse all service paths in the swagger - get the request function models, and all the inline model definitions
-    /// - Parameter swagger: the swagger
-    /// - Parameter swaggerFile: the swagger file
-    /// - Returns: the list of APIs and any inline model definitions found in the paths
-    private func getApiList(fromSwagger swagger: Swagger, swaggerFile: SwaggerFile) throws -> (
-        [APIRequest], [ModelDefinition]
-    ) {
-        var networkRequestFunctions = [APIRequest]()
-        var inlineModelDefinitions = [ModelDefinition]()
-        for swaggerPath in swagger.paths {
-            let (pathNetworkRequestFunctions, pathCurrentInlineDefinitions) = try apisAndModels(
-                fromPath: swaggerPath.value,
-                servicePath: swaggerPath.key,
-                swagger: swagger,
-                swaggerFile: swaggerFile
-            )
+    fields.append(
+      APIDefinitionField(
+        name: "interceptor",
+        description: "use this if you need to intercept overall requests",
+        typeName: "(any NetworkInterceptor)",
+        isRequired: false,
+        typeIsAutoclosure: false,
+        typeIsBlock: false,
+        defaultValue: "nil"
+      )
+    )
 
-            networkRequestFunctions.append(contentsOf: pathNetworkRequestFunctions)
-            inlineModelDefinitions.append(contentsOf: pathCurrentInlineDefinitions)
-        }
-
-        return (networkRequestFunctions, inlineModelDefinitions)
-    }
-
-    func apisAndModels(
-        fromPath path: SwaggerSwiftML.Path, servicePath: String, swagger: Swagger,
-        swaggerFile: SwaggerFile
-    ) throws -> ([APIRequest], [ModelDefinition]) {
-        var apis = [APIRequest]()
-        var modelDefinitions = [ModelDefinition]()
-
-        let parameters: [Parameter] = try (path.parameters ?? []).map(swagger.findParameter(node:))
-
-        for httpMethod in HTTPMethod.allCases {
-            guard let operation = path.operationForMethod(httpMethod)
-            else { continue }
-
-            let (requestFunctions, inlineModelDefinitions) = try apiRequestFactory.generateRequest(
-                for: operation,
-                httpMethod: httpMethod,
-                servicePath: servicePath,
-                swagger: swagger,
-                swaggerFile: swaggerFile,
-                pathParameters: parameters
-            )
-
-            apis.append(requestFunctions)
-            modelDefinitions.append(contentsOf: inlineModelDefinitions)
-        }
-
-        return (apis, modelDefinitions)
-    }
-
-    /// Get the global set of model definitions. This is the normal specified list, and not the inline definitions that are defined in e.g. path definitions and other places
-    /// - Parameter swagger: the swagger
-    /// - Returns: model definitions
-    private func getModelDefinitions(fromSwagger swagger: Swagger) throws -> [ModelDefinition] {
-        guard let definitions = swagger.definitions else {
-            return []
-        }
-
-        var allDefinitions = [ModelDefinition]()
-        for (typeName, schema) in definitions {
-            let resolved = try modelTypeResolver.resolve(
-                forSchema: schema,
-                typeNamePrefix: typeName,
-                namespace: swagger.serviceName,
-                swagger: swagger)
-
-            allDefinitions.append(contentsOf: resolved.inlineModelDefinitions)
-
-            switch resolved.propertyType {
-            case .typeAlias(let typeName, let type):
-                allDefinitions.append(
-                    .typeAlias(.init(typeName: typeName, type: type.toString(required: true))))
-            case .array(let containsType):
-                let arrayModel = ModelDefinition.array(
-                    .init(
-                        description: schema.description, typeName: typeName,
-                        containsType: containsType.toString(required: true)))
-                allDefinitions.append(arrayModel)
-            case .string:
-                allDefinitions.append(
-                    .typeAlias(.init(typeName: typeName, type: "String")))
-            case .int:
-                allDefinitions.append(
-                    .typeAlias(.init(typeName: typeName, type: "Int")))
-            case .double:
-                allDefinitions.append(
-                    .typeAlias(.init(typeName: typeName, type: "Double")))
-            case .float:
-                allDefinitions.append(
-                    .typeAlias(.init(typeName: typeName, type: "Double")))
-            case .boolean:
-                allDefinitions.append(
-                    .typeAlias(.init(typeName: typeName, type: "Bool")))
-            case .int64:
-                allDefinitions.append(
-                    .typeAlias(.init(typeName: typeName, type: "Int64")))
-            case .date:
-                allDefinitions.append(
-                    .typeAlias(.init(typeName: typeName, type: "Date")))
-            case .void:
-                allDefinitions.append(
-                    .typeAlias(.init(typeName: typeName, type: "Void")))
-            case .object: break
-            case .enumeration: break
-            }
-        }
-
-        return allDefinitions
-    }
-
-    /// Get the global set of response model definitions
-    /// - Parameter swagger: the swagger
-    /// - Returns: the set of global response model definitions
-    private func getResponseModelDefinitions(fromSwagger swagger: Swagger) throws -> [ModelDefinition]
-    {
-        var modelDefinitions = [ModelDefinition]()
-        for (typeName, response) in swagger.responses ?? [:] {
-            guard let schema = response.schema else {
-                if response.headers != nil {
-                    log(
-                        "SwaggerSwift does currently not support models without schema but with defined headers"
-                    )
-                    /// TODO: Add support for this
-                    /// Example:
-                    ///  RedirectResponse:
-                    ///    description: Response used to redirect the client to Location
-                    ///    headers:
-                    ///      Location:
-                    ///        type: string
-                }
-
-                continue
-            }
-
-            switch schema {
-            case .reference(let reference):
-                if let (_, typeSchema) = swagger.definitions?.first(where: {
-                    reference == "#/definitions/\($0.key)"
-                }) {
-                    // we dont need the type part as it just represents the primary model definition returned from this function
-                    let resolvedModel = try modelTypeResolver.resolve(
-                        forSchema: typeSchema,
-                        typeNamePrefix: typeName,
-                        namespace: swagger.serviceName,
-                        swagger: swagger)
-                    modelDefinitions.append(contentsOf: resolvedModel.inlineModelDefinitions)
-                } else {
-                    log(
-                        "[\(swagger.serviceName)] Failed to find definition for reference: \(reference)",
-                        error: true)
-                    continue
-                }
-            case .node(let schema):
-                // we dont need the type part as it just represents the primary model definition returned from this function
-                let resolvedModel = try modelTypeResolver.resolve(
-                    forSchema: schema,
-                    typeNamePrefix: typeName,
-                    namespace: swagger.serviceName,
-                    swagger: swagger)
-                modelDefinitions.append(contentsOf: resolvedModel.inlineModelDefinitions)
-            }
-        }
-
-        return modelDefinitions
-    }
-
-    /// The model fields for the API definition
-    /// - Parameter swaggerFile: the swagger file
-    /// - Returns: the model fields
-    private func apiDefinitionsModelFields(swaggerFile: SwaggerFile) -> [APIDefinitionField] {
-        var fields = [
-            APIDefinitionField(
-                name: "urlSession",
-                description:
-                    "the underlying URLSession. This is an autoclosure to allow updated instances to come into this instance.",
-                typeName: "() async -> URLSession",
-                isRequired: true,
-                typeIsAutoclosure: false,
-                typeIsBlock: true,
-                defaultValue: nil
-            ),
-            APIDefinitionField(
-                name: "baseUrlProvider",
-                description:
-                    "the block provider for the baseUrl of the service. The reason this is a block is that this enables automatically updating the network layer on backend environment change.",
-                typeName: "() async -> URL",
-                isRequired: true,
-                typeIsAutoclosure: false,
-                typeIsBlock: true,
-                defaultValue: nil
-            ),
-        ]
-
-        let hasGlobalHeaders = swaggerFile.globalHeaders.count > 0
-
-        if hasGlobalHeaders {
-            fields.append(
-                APIDefinitionField(
-                    name: "headerProvider",
-                    description: "a block provider for the set of globally defined headers",
-                    typeName: "() async -> any GlobalHeaders",
-                    isRequired: true,
-                    typeIsAutoclosure: false,
-                    typeIsBlock: true,
-                    defaultValue: nil
-                )
-            )
-        }
-
-        fields.append(
-            APIDefinitionField(
-                name: "interceptor",
-                description: "use this if you need to intercept overall requests",
-                typeName: "(any NetworkInterceptor)",
-                isRequired: false,
-                typeIsAutoclosure: false,
-                typeIsBlock: false,
-                defaultValue: "nil"
-            )
-        )
-
-        return fields
-    }
+    return fields
+  }
 }

--- a/Sources/SwaggerSwiftCore/Extensions/DataFormat.swift
+++ b/Sources/SwaggerSwiftCore/Extensions/DataFormat.swift
@@ -41,6 +41,8 @@ extension DataFormat: @retroactive CustomStringConvertible {
         return "Int"
       } else if type == "integer" {
         return "Int"
+      } else if type == "uuid" {
+          return "UUID"
       } else {
         fatalError("Unsupported type: \(type)")
       }

--- a/Sources/SwaggerSwiftCore/Extensions/DataFormat.swift
+++ b/Sources/SwaggerSwiftCore/Extensions/DataFormat.swift
@@ -42,7 +42,7 @@ extension DataFormat: @retroactive CustomStringConvertible {
       } else if type == "integer" {
         return "Int"
       } else if type == "uuid" {
-          return "UUID"
+        return "UUID"
       } else {
         fatalError("Unsupported type: \(type)")
       }

--- a/Sources/SwaggerSwiftCore/Generator/Generator.swift
+++ b/Sources/SwaggerSwiftCore/Generator/Generator.swift
@@ -52,9 +52,14 @@ public struct Generator {
 
     var apiSpecs = [APISpec]()
 
+      let apiFactory = APIFactory(
+        apiRequestFactory: apiRequestFactory,
+        modelTypeResolver: modelTypeResolver
+      )
+
     for service in services {
       do {
-        async let swagger = try await downloadSwagger(
+        let swagger = try await downloadSwagger(
           githubToken: githubToken,
           organisation: swaggerFile.organisation,
           serviceName: service.key,
@@ -62,10 +67,10 @@ public struct Generator {
           swaggerPath: service.value.path ?? swaggerFile.path
         )
 
-        let apiSpec = try await APIFactory(
-          apiRequestFactory: apiRequestFactory,
-          modelTypeResolver: modelTypeResolver
-        ).generate(for: swagger, withSwaggerFile: swaggerFile)
+          let apiSpec = try apiFactory.generate(
+            for: swagger,
+            withSwaggerFile: swaggerFile
+          )
 
         apiSpecs.append(apiSpec)
       } catch {

--- a/Sources/SwaggerSwiftCore/Generator/Generator.swift
+++ b/Sources/SwaggerSwiftCore/Generator/Generator.swift
@@ -52,10 +52,10 @@ public struct Generator {
 
     var apiSpecs = [APISpec]()
 
-      let apiFactory = APIFactory(
-        apiRequestFactory: apiRequestFactory,
-        modelTypeResolver: modelTypeResolver
-      )
+    let apiFactory = APIFactory(
+      apiRequestFactory: apiRequestFactory,
+      modelTypeResolver: modelTypeResolver
+    )
 
     for service in services {
       do {
@@ -67,10 +67,10 @@ public struct Generator {
           swaggerPath: service.value.path ?? swaggerFile.path
         )
 
-          let apiSpec = try apiFactory.generate(
-            for: swagger,
-            withSwaggerFile: swaggerFile
-          )
+        let apiSpec = try apiFactory.generate(
+          for: swagger,
+          withSwaggerFile: swaggerFile
+        )
 
         apiSpecs.append(apiSpec)
       } catch {

--- a/Sources/SwaggerSwiftCore/Model Type Resolver/ModelTypeResolver.swift
+++ b/Sources/SwaggerSwiftCore/Model Type Resolver/ModelTypeResolver.swift
@@ -51,15 +51,21 @@ public struct ModelTypeResolver {
       return .init(type)
     case .integer(let format, _, _, _, _, _, let defaultValue):
       let type = IntegerResolver.resolve(
-        serviceName: swagger.serviceName, format: format, defaultValue: defaultValue)
+        serviceName: swagger.serviceName,
+        format: format,
+        defaultValue: defaultValue
+      )
+
       return .init(type)
 
     case .number(let format, _, _, _, _, _, let defaultValue):
       let type = NumberResolver.resolve(
         format: format,
         defaultValue: defaultValue,
-        serviceName: swagger.serviceName)
-      return .init(type)
+        serviceName: swagger.serviceName
+      )
+
+      return ResolvedModel(type)
     case .boolean(let defaultValue):
       let type = BooleanResolver.resolve(with: defaultValue)
       return .init(type)

--- a/Sources/SwaggerSwiftCore/Model Type Resolver/Resolvers/NumberResolver.swift
+++ b/Sources/SwaggerSwiftCore/Model Type Resolver/Resolvers/NumberResolver.swift
@@ -2,58 +2,58 @@ import Foundation
 import SwaggerSwiftML
 
 enum NumberResolver {
-  static func resolve(format: DataFormat?, defaultValue: Double?, serviceName: String) -> TypeType {
-    if let format = format {
-      switch format {
-      case .long:
-        return .double(defaultValue: defaultValue)
-      case .float:
-        if let defaultValue = defaultValue {
-          return .float(defaultValue: Float(defaultValue))
-        } else {
-          return .float(defaultValue: nil)
+    static func resolve(format: DataFormat?, defaultValue: Double?, serviceName: String) -> TypeType {
+        guard let format = format else {
+            return .double(defaultValue: defaultValue)
         }
-      case .int32:
-        if let defaultValue = defaultValue {
-          return .int(defaultValue: Int(defaultValue))
-        } else {
-          return .int(defaultValue: nil)
-        }
-      case .double:
-        return .double(defaultValue: defaultValue)
-      case .date, .dateTime, .password, .email, .string, .byte, .binary, .boolean:
-        log("⚠️: \(serviceName): SwaggerSwift does not support '\(format)' for number", error: true)
-        return .double(defaultValue: defaultValue)
-      case .unsupported(let unsupported):
-        switch unsupported {
-        case "int", "integer":
-          if let defaultValue = defaultValue {
-            return .int(defaultValue: Int(defaultValue))
-          } else {
-            return .int(defaultValue: nil)
-          }
-        case "int64":
-          if let defaultValue = defaultValue {
-            return .int64(defaultValue: Int64(defaultValue))
-          } else {
-            return .int64(defaultValue: nil)
-          }
-        case "float64":
-          log(
-            "⚠️:\(serviceName): `format: float64` format does not exist for type number in the Swagger spec. Please change it to specify `format: double` instead.",
-            error: true)
-          return .double(defaultValue: defaultValue)
-        case "decimal":
-          return .double(defaultValue: defaultValue)
-        default:
-          log(
-            "⚠️: \(serviceName): SwaggerSwift does not support '\(unsupported)' for number",
-            error: true)
-          return .double(defaultValue: defaultValue)
-        }
-      }
-    }
 
-    return .double(defaultValue: defaultValue)
-  }
+        switch format {
+        case .long:
+            return .double(defaultValue: defaultValue)
+        case .float:
+            if let defaultValue = defaultValue {
+                return .float(defaultValue: Float(defaultValue))
+            } else {
+                return .float(defaultValue: nil)
+            }
+        case .int32:
+            if let defaultValue = defaultValue {
+                return .int(defaultValue: Int(defaultValue))
+            } else {
+                return .int(defaultValue: nil)
+            }
+        case .double:
+            return .double(defaultValue: defaultValue)
+        case .date, .dateTime, .password, .email, .string, .byte, .binary, .boolean:
+            log("⚠️: \(serviceName): SwaggerSwift does not support '\(format)' for number", error: true)
+            return .double(defaultValue: defaultValue)
+        case .unsupported(let unsupported):
+            switch unsupported {
+            case "int", "integer":
+                if let defaultValue = defaultValue {
+                    return .int(defaultValue: Int(defaultValue))
+                } else {
+                    return .int(defaultValue: nil)
+                }
+            case "int64":
+                if let defaultValue = defaultValue {
+                    return .int64(defaultValue: Int64(defaultValue))
+                } else {
+                    return .int64(defaultValue: nil)
+                }
+            case "float64":
+                log(
+                    "⚠️:\(serviceName): `format: float64` format does not exist for type number in the Swagger spec. Please change it to specify `format: double` instead.",
+                    error: true)
+                return .double(defaultValue: defaultValue)
+            case "decimal":
+                return .double(defaultValue: defaultValue)
+            default:
+                log(
+                    "⚠️: \(serviceName): SwaggerSwift does not support '\(unsupported)' for number",
+                    error: true)
+                return .double(defaultValue: defaultValue)
+            }
+        }
+    }
 }

--- a/Sources/SwaggerSwiftCore/Model Type Resolver/Resolvers/NumberResolver.swift
+++ b/Sources/SwaggerSwiftCore/Model Type Resolver/Resolvers/NumberResolver.swift
@@ -2,58 +2,58 @@ import Foundation
 import SwaggerSwiftML
 
 enum NumberResolver {
-    static func resolve(format: DataFormat?, defaultValue: Double?, serviceName: String) -> TypeType {
-        guard let format = format else {
-            return .double(defaultValue: defaultValue)
-        }
-
-        switch format {
-        case .long:
-            return .double(defaultValue: defaultValue)
-        case .float:
-            if let defaultValue = defaultValue {
-                return .float(defaultValue: Float(defaultValue))
-            } else {
-                return .float(defaultValue: nil)
-            }
-        case .int32:
-            if let defaultValue = defaultValue {
-                return .int(defaultValue: Int(defaultValue))
-            } else {
-                return .int(defaultValue: nil)
-            }
-        case .double:
-            return .double(defaultValue: defaultValue)
-        case .date, .dateTime, .password, .email, .string, .byte, .binary, .boolean:
-            log("⚠️: \(serviceName): SwaggerSwift does not support '\(format)' for number", error: true)
-            return .double(defaultValue: defaultValue)
-        case .unsupported(let unsupported):
-            switch unsupported {
-            case "int", "integer":
-                if let defaultValue = defaultValue {
-                    return .int(defaultValue: Int(defaultValue))
-                } else {
-                    return .int(defaultValue: nil)
-                }
-            case "int64":
-                if let defaultValue = defaultValue {
-                    return .int64(defaultValue: Int64(defaultValue))
-                } else {
-                    return .int64(defaultValue: nil)
-                }
-            case "float64":
-                log(
-                    "⚠️:\(serviceName): `format: float64` format does not exist for type number in the Swagger spec. Please change it to specify `format: double` instead.",
-                    error: true)
-                return .double(defaultValue: defaultValue)
-            case "decimal":
-                return .double(defaultValue: defaultValue)
-            default:
-                log(
-                    "⚠️: \(serviceName): SwaggerSwift does not support '\(unsupported)' for number",
-                    error: true)
-                return .double(defaultValue: defaultValue)
-            }
-        }
+  static func resolve(format: DataFormat?, defaultValue: Double?, serviceName: String) -> TypeType {
+    guard let format = format else {
+      return .double(defaultValue: defaultValue)
     }
+
+    switch format {
+    case .long:
+      return .double(defaultValue: defaultValue)
+    case .float:
+      if let defaultValue = defaultValue {
+        return .float(defaultValue: Float(defaultValue))
+      } else {
+        return .float(defaultValue: nil)
+      }
+    case .int32:
+      if let defaultValue = defaultValue {
+        return .int(defaultValue: Int(defaultValue))
+      } else {
+        return .int(defaultValue: nil)
+      }
+    case .double:
+      return .double(defaultValue: defaultValue)
+    case .date, .dateTime, .password, .email, .string, .byte, .binary, .boolean:
+      log("⚠️: \(serviceName): SwaggerSwift does not support '\(format)' for number", error: true)
+      return .double(defaultValue: defaultValue)
+    case .unsupported(let unsupported):
+      switch unsupported {
+      case "int", "integer":
+        if let defaultValue = defaultValue {
+          return .int(defaultValue: Int(defaultValue))
+        } else {
+          return .int(defaultValue: nil)
+        }
+      case "int64":
+        if let defaultValue = defaultValue {
+          return .int64(defaultValue: Int64(defaultValue))
+        } else {
+          return .int64(defaultValue: nil)
+        }
+      case "float64":
+        log(
+          "⚠️:\(serviceName): `format: float64` format does not exist for type number in the Swagger spec. Please change it to specify `format: double` instead.",
+          error: true)
+        return .double(defaultValue: defaultValue)
+      case "decimal":
+        return .double(defaultValue: defaultValue)
+      default:
+        log(
+          "⚠️: \(serviceName): SwaggerSwift does not support '\(unsupported)' for number",
+          error: true)
+        return .double(defaultValue: defaultValue)
+      }
+    }
+  }
 }

--- a/Sources/SwaggerSwiftCore/Static Files/StringCodingKey.swift
+++ b/Sources/SwaggerSwiftCore/Static Files/StringCodingKey.swift
@@ -1,6 +1,4 @@
 let stringCodingKey = """
-  public import Foundation
-
   <ACCESSCONTROL> struct StringCodingKey: CodingKey, ExpressibleByStringLiteral {
       private let string: String
       private var int: Int?


### PR DESCRIPTION
If a SwaggerFile contains a global primitive like
```
definitions:
  Ratio:
    type: number
```

then SwaggerSwift will now generate that as a global typealias.